### PR TITLE
Rules catalog

### DIFF
--- a/DocsExamples/Example-RulesCatalog.json
+++ b/DocsExamples/Example-RulesCatalog.json
@@ -1,0 +1,29 @@
+{
+  "name": "Enterprise Fabric Rules Catalog",
+  "ruleSets": [
+    {
+      "name": "Community baseline",
+      "type": "url",
+      "path": "https://contoso.github.io/fab-rules/community-rules.json"
+    },
+    {
+      "name": "Org baseline",
+      "type": "onelake",
+      "path": "https://onelake.dfs.fabric.microsoft.com/YourWorkspace/YourLakehouse.Lakehouse/Files/rules/org-baseline.json"
+    },
+    {
+      "name": "Domain rules",
+      "type": "local",
+      "path": "./domain/domain-rules.json"
+    },
+    {
+      "name": "Local overrides",
+      "path": "./local/local-overrides.json"
+    },
+    {
+      "name": "Temporary disabled ruleset",
+      "path": "./local/wip-rules.json",
+      "disabled": true
+    }
+  ]
+}

--- a/FabInspector.ClientLibrary/Files/html/TestRunTemplate.html
+++ b/FabInspector.ClientLibrary/Files/html/TestRunTemplate.html
@@ -69,6 +69,11 @@
 
                     <form id="resultFilters" class="filter-grid" autocomplete="off">
                         <div>
+                            <label for="filterRuleSetName" class="form-label small mb-1">Ruleset Name</label>
+                            <input id="filterRuleSetName" name="ruleSetName" type="search" class="form-control form-control-sm" placeholder="Contains...">
+                        </div>
+
+                        <div>
                             <label for="filterRuleName" class="form-label small mb-1">Rule Name</label>
                             <input id="filterRuleName" name="ruleName" type="search" class="form-control form-control-sm" placeholder="Contains...">
                         </div>
@@ -104,7 +109,7 @@
                                 <option value="true">Pass</option>
                                 <option value="false">Fail</option>
                             </select>
-                            <div id="filterPassNotice" class="form-text d-none">Pass filter is unavailable because Verbose is false. Only test failures are displayed.</div>
+                            <div id="filterPassNotice" class="form-text d-none">Verbose was set to false so only test failures are displayed.</div>
                         </div>
                     </form>
 
@@ -128,6 +133,20 @@
         const testRunHeaderTemplate = {
             "<>": "div",
             "html": [
+                {
+                    "<>": "div",
+                    "class": "d-flex text-body-secondary pt-3",
+                    "html": [
+                        {
+                            "<>": "p",
+                            "class": function () {
+                                return this.RulesCatalogPath ? "pb-3 mb-0 small lh-sm" : "pb-3 mb-0 small lh-sm d-none";
+                            },
+                            "html": [{ "<>": "strong", "class": "d-block text-gray-dark", "text": "Rules Catalog Path" }, { "text": function () { return this.RulesCatalogPath || ""; } }]
+                        }
+                    ]
+                },
+
                 {
                     "<>": "div",
                     "class": "d-flex text-body-secondary pt-3",
@@ -168,7 +187,20 @@
                         {
                             "<>": "p",
                             "class": "pb-3 mb-0 small lh-sm",
-                            "html": [{ "<>": "strong", "class": "d-block text-gray-dark", "text": "Rules File Path" }, { "text": "${RulesFilePath}" }]
+                            "html": [
+                                {
+                                    "<>": "strong",
+                                    "class": "d-block text-gray-dark",
+                                    "text": function () {
+                                        return this.RulesCatalogPath ? "Rules Catalog File Path" : "Rules File Path";
+                                    }
+                                },
+                                {
+                                    "text": function () {
+                                        return this.RulesCatalogPath || this.RulesFilePath || "";
+                                    }
+                                }
+                            ]
                         }
                     ]
                 },
@@ -237,6 +269,42 @@
                                         {
                                             "<>": "span",
                                             "html": [
+                                                {
+                                                    "<>": "p",
+                                                    "class": function () {
+                                                        return this.RuleSetName ? "pb-3 mb-0 small lh-sm" : "pb-3 mb-0 small lh-sm d-none";
+                                                    },
+                                                    "html": [
+                                                        {
+                                                            "<>": "strong",
+                                                            "class": "d-block text-gray-dark",
+                                                            "text": "Ruleset Name"
+                                                        },
+                                                        {
+                                                            "text": function () {
+                                                                return this.RuleSetName || "";
+                                                            }
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "<>": "p",
+                                                    "class": function () {
+                                                        return this.RuleSetPath ? "pb-3 mb-0 small lh-sm" : "pb-3 mb-0 small lh-sm d-none";
+                                                    },
+                                                    "html": [
+                                                        {
+                                                            "<>": "strong",
+                                                            "class": "d-block text-gray-dark",
+                                                            "text": "Ruleset Path"
+                                                        },
+                                                        {
+                                                            "text": function () {
+                                                                return this.RuleSetPath || "";
+                                                            }
+                                                        }
+                                                    ]
+                                                },
                                                 {
                                                     "<>": "p",
                                                     "class": "pb-3 mb-0 small lh-sm",
@@ -405,6 +473,7 @@
             const passFilterDisabled = $("#filterPass").prop("disabled");
 
             return {
+                ruleSetName: normalizeText($("#filterRuleSetName").val()),
                 ruleName: normalizeText($("#filterRuleName").val()),
                 logType: $("#filterLogType").val(),
                 ruleItemType: normalizeText($("#filterRuleItemType").val()),
@@ -477,7 +546,8 @@
             const filters = getActiveFilters();
 
             const filteredResults = allResults.filter(function (item) {
-                return matchesContains(item.RuleName, filters.ruleName)
+                return matchesContains(item.RuleSetName, filters.ruleSetName)
+                    && matchesContains(item.RuleName, filters.ruleName)
                     && matchLogType(item, filters.logType)
                     && matchesContains(item.RuleItemType, filters.ruleItemType)
                     && matchesContains(item.ItemPath, filters.itemPath)

--- a/FabInspector.ClientLibrary/Main.cs
+++ b/FabInspector.ClientLibrary/Main.cs
@@ -135,28 +135,14 @@ namespace FabInspector.ClientLibrary
 
             SetPartContext();
 
-            var rules = await Task.Run(() => DeserialiseRulesFromPath(args.RulesFilePath ?? string.Empty)).ConfigureAwait(false);
-
-            IEnumerable<TestResult> testResults;
-            if (args.Parallel)
-            {
-                var ruleBuckets = ChunkInspectionRules(rules);
-                var tasks = ruleBuckets.Select(async bucket => await RunSingleThreadedCoreAsync(bucket, registries).ConfigureAwait(false));
-                var allResults = await Task.WhenAll(tasks).ConfigureAwait(false);
-                testResults = allResults.SelectMany(r => r ?? Enumerable.Empty<TestResult>()).OrderBy(r => r.RuleId);
-            }
-            else
-            {
-                testResults = await RunSingleThreadedCoreAsync(rules, registries).ConfigureAwait(false) ?? Enumerable.Empty<TestResult>();
-            }
-
-            testResults = FilterResults(testResults);
+            var testResults = await ExecuteRuleSetsAsync(args, registries).ConfigureAwait(false);
 
             return new TestRun
             {
                 CompletionTime = DateTime.UtcNow,
                 TestedFilePath = args.FabricItem,
                 RulesFilePath = args.RulesFilePath,
+                RulesCatalogPath = args.RulesCatalogPath,
                 Verbose = args.Verbose,
                 Results = testResults
             };
@@ -225,6 +211,8 @@ namespace FabInspector.ClientLibrary
 
         public static async Task Run(Args args, IReportPageWireframeRenderer pageRenderer, IEnumerable<JsonLogicOperatorRegistry> registries)
         {
+            _args = args;
+
             // Authenticate based on auth method
             if (args.AuthMethod != "local")
             {
@@ -251,14 +239,12 @@ namespace FabInspector.ClientLibrary
         public static async Task RunSingleThreadedAsync(Args args, IReportPageWireframeRenderer pageRenderer, IEnumerable<JsonLogicOperatorRegistry> registries)
         {
             _args = args;
-            IEnumerable<TestResult>? testResults = null;
             
             OnMessageIssued(MessageTypeEnum.Information, string.Concat("Test run started at (UTC): ", DateTime.Now.ToUniversalTime()));
 
             SetPartContext();
 
-            var rules = await Task.Run(() => DeserialiseRulesFromPath(args.RulesFilePath ?? string.Empty)).ConfigureAwait(false);
-            testResults = await RunSingleThreadedAsync(rules, registries).ConfigureAwait(false);
+            var testResults = await ExecuteRuleSetsAsync(args, registries).ConfigureAwait(false);
 
             if (testResults != null && testResults.Any())
             {
@@ -275,27 +261,80 @@ namespace FabInspector.ClientLibrary
         {
             _args = args;
 
-            SetPartContext();
-
-            var rules = await Task.Run(() => DeserialiseRulesFromPath(args.RulesFilePath ?? string.Empty)).ConfigureAwait(false);
-            var ruleBuckets = ChunkInspectionRules(rules);
-            var globalResults = new ConcurrentBag<TestResult>();
-
             OnMessageIssued(MessageTypeEnum.Information, string.Concat("Parallel test run started at (UTC): ", DateTime.Now.ToUniversalTime()));
 
-            var tasks = ruleBuckets.Select(async bucket => await RunSingleThreadedAsync(bucket, registries).ConfigureAwait(false));
-            var allResults = await Task.WhenAll(tasks).ConfigureAwait(false);
+            SetPartContext();
 
-            foreach (var localResults in allResults)
+            var testResults = await ExecuteRuleSetsAsync(args, registries).ConfigureAwait(false);
+            await OutputResultsAsync(testResults, pageRenderer, registries).ConfigureAwait(false);
+            OnMessageIssued(MessageTypeEnum.Complete, string.Concat("Test run completed at (UTC): ", DateTime.Now.ToUniversalTime()));
+        }
+
+        private static async Task<IEnumerable<TestResult>> ExecuteRuleSetsAsync(Args args, IEnumerable<JsonLogicOperatorRegistry> registries)
+        {
+            var resolvedRuleSets = await ResolveRuleSetsAsync(args).ConfigureAwait(false);
+            var combinedResults = new List<TestResult>();
+
+            foreach (var ruleSet in resolvedRuleSets)
             {
-                foreach (var result in localResults ?? Enumerable.Empty<TestResult>())
+                try
                 {
-                    globalResults.Add(result);
+                    OnMessageIssued(MessageTypeEnum.Information, $"Running ruleset '{ruleSet.Name}' from '{ruleSet.SourcePath}'.");
+                    var currentResults = await ExecuteSingleRuleSetAsync(ruleSet, registries, args.Parallel).ConfigureAwait(false);
+                    combinedResults.AddRange(currentResults);
+                }
+                catch (Exception ex) when (!string.IsNullOrWhiteSpace(args.RulesCatalogPath))
+                {
+                    OnMessageIssued(MessageTypeEnum.Error, $"Failed to execute ruleset '{ruleSet.Name}' from '{ruleSet.SourcePath}'. {ex.Message}");
                 }
             }
 
-            await OutputResultsAsync(globalResults.ToList().OrderBy(_ => _.RuleId), pageRenderer, registries).ConfigureAwait(false);
-            OnMessageIssued(MessageTypeEnum.Complete, string.Concat("Test run completed at (UTC): ", DateTime.Now.ToUniversalTime()));
+            return combinedResults.OrderBy(_ => _.RuleId).ToList();
+        }
+
+        private static async Task<IReadOnlyList<ResolvedRuleSet>> ResolveRuleSetsAsync(Args args)
+        {
+            if (!string.IsNullOrWhiteSpace(args.RulesCatalogPath))
+            {
+                var reader = new RulesCatalogReader(_tokenProvider, _httpClient,
+                    onProgress: msg => OnMessageIssued(MessageTypeEnum.Information, msg));
+                return await reader.ReadResolvedRuleSetsAsync(args.RulesCatalogPath).ConfigureAwait(false);
+            }
+
+            var rules = await Task.Run(() => DeserialiseRulesFromPath(args.RulesFilePath ?? string.Empty)).ConfigureAwait(false);
+            return new List<ResolvedRuleSet>
+            {
+                new ResolvedRuleSet
+                {
+                    Name = "Rules",
+                    SourcePath = args.RulesFilePath ?? string.Empty,
+                    Rules = rules
+                }
+            };
+        }
+
+        private static async Task<IEnumerable<TestResult>> ExecuteSingleRuleSetAsync(ResolvedRuleSet ruleSet, IEnumerable<JsonLogicOperatorRegistry> registries, bool parallel)
+        {
+            IEnumerable<TestResult> results;
+
+            if (parallel)
+            {
+                var ruleBuckets = ChunkInspectionRules(ruleSet.Rules);
+                var tasks = ruleBuckets.Select(async bucket => await RunSingleThreadedAsync(bucket, registries).ConfigureAwait(false));
+                var allResults = await Task.WhenAll(tasks).ConfigureAwait(false);
+                results = allResults.SelectMany(r => r ?? Enumerable.Empty<TestResult>());
+            }
+            else
+            {
+                results = await RunSingleThreadedAsync(ruleSet.Rules, registries).ConfigureAwait(false) ?? Enumerable.Empty<TestResult>();
+            }
+
+            return results.Select(result =>
+            {
+                result.RuleSetName = ruleSet.Name;
+                result.RuleSetPath = ruleSet.SourcePath;
+                return result;
+            });
         }
 
         private static void SetPartContext()

--- a/FabInspector.ClientLibrary/Main.cs
+++ b/FabInspector.ClientLibrary/Main.cs
@@ -289,7 +289,7 @@ namespace FabInspector.ClientLibrary
                 }
             }
 
-            return combinedResults.OrderBy(_ => _.RuleId).ToList();
+            return combinedResults;
         }
 
         private static async Task<IReadOnlyList<ResolvedRuleSet>> ResolveRuleSetsAsync(Args args)

--- a/FabInspector.ClientLibrary/Output/ConsoleResultWriter.cs
+++ b/FabInspector.ClientLibrary/Output/ConsoleResultWriter.cs
@@ -10,7 +10,9 @@ namespace FabInspector.ClientLibrary.Output
             {
                 //TODO: use Test log type json property instead
                 var msgType = result.Pass ? MessageTypeEnum.Information : result.LogType;
-                context.OnItemMessage(result.ItemPath ?? string.Empty, msgType, result.Message);
+                var ruleSetName = string.IsNullOrWhiteSpace(result.RuleSetName) ? "Unknown" : result.RuleSetName;
+                var message = string.Concat("[Ruleset: ", ruleSetName, "] ", result.Message);
+                context.OnItemMessage(result.ItemPath ?? string.Empty, msgType, message);
             }
 
             if (context.TestResults.Any())

--- a/FabInspector.ClientLibrary/Output/JsonResultWriter.cs
+++ b/FabInspector.ClientLibrary/Output/JsonResultWriter.cs
@@ -24,6 +24,7 @@ namespace FabInspector.ClientLibrary.Output
                 CompletionTime = DateTime.Now,
                 TestedFilePath = context.TestedFilePath,
                 RulesFilePath = context.RulesFilePath,
+                RulesCatalogPath = context.RulesCatalogPath,
                 Verbose = context.Verbose,
                 Results = context.TestResults
             };

--- a/FabInspector.ClientLibrary/Output/OutputContext.cs
+++ b/FabInspector.ClientLibrary/Output/OutputContext.cs
@@ -10,6 +10,7 @@ namespace FabInspector.ClientLibrary.Output
         public required bool IsOneLakeOutput { get; init; }
         public required string TestedFilePath { get; init; }
         public string? RulesFilePath { get; init; }
+        public string? RulesCatalogPath { get; init; }
         public bool Verbose { get; init; }
         public bool OverwriteOutput { get; init; }
         public string? FabricItem { get; init; }

--- a/FabInspector.ClientLibrary/Output/ResultOutputOrchestrator.cs
+++ b/FabInspector.ClientLibrary/Output/ResultOutputOrchestrator.cs
@@ -66,6 +66,7 @@ namespace FabInspector.ClientLibrary.Output
                     IsOneLakeOutput = isOneLakeOutput,
                     TestedFilePath = BuildTestedFilePath(),
                     RulesFilePath = _args.RulesFilePath,
+                    RulesCatalogPath = _args.RulesCatalogPath,
                     Verbose = _args.Verbose,
                     OverwriteOutput = _args.OverwriteOutput,
                     FabricItem = _args.FabricItem,

--- a/FabInspector.ClientLibrary/Utils/Args.cs
+++ b/FabInspector.ClientLibrary/Utils/Args.cs
@@ -7,6 +7,8 @@ namespace FabInspector.ClientLibrary.Utils
 
         public string? RulesFilePath { get; set; }
 
+        public string? RulesCatalogPath { get; set; }
+
         public string OutputPath
         {
             set

--- a/FabInspector.ClientLibrary/Utils/ArgsUtils.cs
+++ b/FabInspector.ClientLibrary/Utils/ArgsUtils.cs
@@ -13,6 +13,7 @@ FabInspector CLI - Power BI / Fabric Inspector Command Line Tool
 
 USAGE:
   fab-inspector -fabricitem <path> -rules <path> [options]
+  fab-inspector -fabricitem <path> -rulescatalog <path> [options]
   fab-inspector serve
 
 MCP SERVER MODE:
@@ -34,6 +35,8 @@ REQUIRED PARAMETERS:
                                   Legacy behaviour: path to local Power BI report's .pbip file path or .Report folder path also works but is deprecated.
   
   -rules <path>                   Path to rules file (JSON) or OneLake URL to rules file (latter requires authentication)
+  -rulescatalog <path>            Path to rules catalog file (JSON) or OneLake URL to catalog file
+                                  Exactly one of -rules or -rulescatalog must be specified
   
 ALTERNATIVE INPUT OPTIONS (use one of these):
   -pbipreport <path>              Deprecated: Path to Power BI file
@@ -92,6 +95,9 @@ EXAMPLES:
   
   # Generate HTML output
   fab-inspector -fabricitem report.pbip -rules rules.json -output results -formats HTML
+
+  # Run multiple rulesets from a catalog
+  fab-inspector -fabricitem report.pbip -rulescatalog rules-catalog.json -formats JSON
   
   # Analyze Fabric workspace with client secret authentication, output to OneLake in JSON format
   fab-inspector -fabricworkspace a1b2c3d4-e5f6-g7h8-i9j0-k1l2m3n4o5p6 -rules rules.json ^
@@ -122,9 +128,9 @@ For more information, visit: https://github.com/NatVanG/fab-inspector
 
         public static Args ParseArgs(string[] args)
         {
-            const string PBIX = "-pbix", PBIP = "-pbip", PBIPREPORT = "-pbipreport", FABRICITEM = "-fabricitem", FABRICWORKSPACE = "-fabricworkspace", RULES = "-rules", OUTPUT = "-output", FORMATS = "-formats", VERBOSE = "-verbose", PARALLEL = "-parallel", OVERWRITEOUTPUT = "-overwriteoutput", AUTHMETHOD = "-authmethod", TENANTID = "-tenantid", CLIENTID = "-clientid", CLIENTSECRET = "-clientsecret", CERTIFICATEPATH = "-certificatepath", CERTIFICATEPASSWORD = "-certificatepassword", FEDERATEDTOKEN = "-federatedtoken", HELP = "-help";
+            const string PBIX = "-pbix", PBIP = "-pbip", PBIPREPORT = "-pbipreport", FABRICITEM = "-fabricitem", FABRICWORKSPACE = "-fabricworkspace", RULES = "-rules", RULESCATALOG = "-rulescatalog", OUTPUT = "-output", FORMATS = "-formats", VERBOSE = "-verbose", PARALLEL = "-parallel", OVERWRITEOUTPUT = "-overwriteoutput", AUTHMETHOD = "-authmethod", TENANTID = "-tenantid", CLIENTID = "-clientid", CLIENTSECRET = "-clientsecret", CERTIFICATEPATH = "-certificatepath", CERTIFICATEPASSWORD = "-certificatepassword", FEDERATEDTOKEN = "-federatedtoken", HELP = "-help";
             const string FALSE = "false";
-            string[] validOptions = { PBIX, PBIP, PBIPREPORT, FABRICITEM, FABRICWORKSPACE, RULES, OUTPUT, FORMATS, VERBOSE, PARALLEL, OVERWRITEOUTPUT, AUTHMETHOD, TENANTID, CLIENTID, CLIENTSECRET, CERTIFICATEPATH, CERTIFICATEPASSWORD, FEDERATEDTOKEN, HELP };
+            string[] validOptions = { PBIX, PBIP, PBIPREPORT, FABRICITEM, FABRICWORKSPACE, RULES, RULESCATALOG, OUTPUT, FORMATS, VERBOSE, PARALLEL, OVERWRITEOUTPUT, AUTHMETHOD, TENANTID, CLIENTID, CLIENTSECRET, CERTIFICATEPATH, CERTIFICATEPASSWORD, FEDERATEDTOKEN, HELP };
 
             int index = 0;
             int maxindex = args.Length - 2;
@@ -147,10 +153,16 @@ For more information, visit: https://github.com/NatVanG/fab-inspector
             if (dic.ContainsKey(PBIX)) { throw new ArgumentNullException("-pbix option is not currently supported use -pbip instead.");  }
             if (!dic.ContainsKey(PBIPREPORT) && !dic.ContainsKey(PBIP) && !dic.ContainsKey(FABRICITEM) && !dic.ContainsKey(FABRICWORKSPACE)) { throw new ArgumentNullException("-pbipreport, -pbip, -fabricitem, or -fabricworkspace must be defined."); }
 
-            if (!dic.ContainsKey(RULES)) { throw new ArgumentNullException("-rules must be defined"); }
+            var hasRules = dic.ContainsKey(RULES);
+            var hasRulesCatalog = dic.ContainsKey(RULESCATALOG);
+            if (hasRules == hasRulesCatalog)
+            {
+              throw new ArgumentNullException("Exactly one of -rules or -rulescatalog must be defined.");
+            }
 
             var pbiFilePath = dic.ContainsKey(PBIPREPORT) ? dic[PBIPREPORT] : (dic.ContainsKey(PBIP) ? dic[PBIP] : (dic.ContainsKey(FABRICITEM) ? dic[FABRICITEM] : string.Empty));
-            var rulesPath = dic[RULES];
+            var rulesPath = hasRules ? dic[RULES] : string.Empty;
+            var rulesCatalogPath = hasRulesCatalog ? dic[RULESCATALOG] : string.Empty;
             var outputPath = dic.ContainsKey(OUTPUT) ? dic[OUTPUT] : string.Empty;
             var verboseString = dic.ContainsKey(VERBOSE) ? dic[VERBOSE] : FALSE;
             var parallelString = dic.ContainsKey(PARALLEL) ? dic[PARALLEL] : FALSE;
@@ -226,6 +238,11 @@ For more information, visit: https://github.com/NatVanG/fab-inspector
                 throw new ArgumentException("OneLake rules URL requires authentication. Use -authmethod interactive, azurecli, clientsecret, certificate, federatedtoken, or managedidentity.");
             }
 
+            if (OneLakeRulesFileDownloader.IsOneLakeDfsUrl(rulesCatalogPath) && authMethod == "local")
+            {
+              throw new ArgumentException("OneLake rules catalog URL requires authentication. Use -authmethod interactive, azurecli, clientsecret, certificate, federatedtoken, or managedidentity.");
+            }
+
             if (OneLakeOutputUploader.IsOneLakeDfsUrl(outputPath) && authMethod == "local")
             {
                 throw new ArgumentException("OneLake output URL requires authentication. Use -authmethod interactive, azurecli, clientsecret, certificate, federatedtoken, or managedidentity.");
@@ -262,6 +279,7 @@ For more information, visit: https://github.com/NatVanG/fab-inspector
             { 
                 FabricItem = pbiFilePath, 
                 RulesFilePath = rulesPath, 
+                RulesCatalogPath = rulesCatalogPath,
                 OutputPath = outputPath, 
                 FormatsString = formatsString, 
                 VerboseString = verboseString, 

--- a/FabInspector.ClientLibrary/Utils/OneLakeRulesFileDownloader.cs
+++ b/FabInspector.ClientLibrary/Utils/OneLakeRulesFileDownloader.cs
@@ -6,7 +6,7 @@ namespace FabInspector.ClientLibrary.Utils
 {
     internal static class OneLakeRulesFileDownloader
     {
-        private const string RequiredUrlPrefix = "https://onelake.dfs.fabric.microsoft.com";
+        public const string RequiredUrlPrefix = "https://onelake.dfs.fabric.microsoft.com";
 
         public static bool IsOneLakeDfsUrl(string? path)
         {

--- a/FabInspector.ClientLibrary/Utils/ResolvedRuleSet.cs
+++ b/FabInspector.ClientLibrary/Utils/ResolvedRuleSet.cs
@@ -1,0 +1,13 @@
+using FabInspector.Core;
+
+namespace FabInspector.ClientLibrary.Utils
+{
+    public sealed class ResolvedRuleSet
+    {
+        public required string Name { get; init; }
+
+        public required string SourcePath { get; init; }
+
+        public required InspectionRules Rules { get; init; }
+    }
+}

--- a/FabInspector.ClientLibrary/Utils/RuleSetReferences.cs
+++ b/FabInspector.ClientLibrary/Utils/RuleSetReferences.cs
@@ -1,0 +1,43 @@
+using FabInspector.Core;
+
+namespace FabInspector.ClientLibrary.Utils
+{
+    public sealed class RuleSetReference : IRuleSet
+    {
+        public string Name { get; set; } = string.Empty;
+
+        public bool Disabled { get; set; } = false;
+
+        public string Path { get; set; } = string.Empty;
+
+        public string? Type { get; set; }
+        public static string DetectType(string? type, string path)
+        {
+            if (!string.IsNullOrWhiteSpace(type))
+            {
+                var normalisedType = type.Trim().ToLowerInvariant();
+                return normalisedType switch
+                {
+                    "local" or "file" => "local",
+                    "onelake" => "onelake",
+                    "url" or "http" or "https" => "url",
+                    _ => throw new InvalidOperationException($"Unsupported ruleset type '{type}'.")
+                };
+            }
+
+            if (OneLakeRulesFileDownloader.IsOneLakeDfsUrl(path))
+            {
+                return "onelake";
+            }
+
+            if (Uri.TryCreate(path, UriKind.Absolute, out var uri)
+                && (uri.Scheme.Equals(Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase)
+                    || uri.Scheme.Equals(Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase)))
+            {
+                return "url";
+            }
+
+            return "local";
+        }
+    }
+}

--- a/FabInspector.ClientLibrary/Utils/RulesCatalog.cs
+++ b/FabInspector.ClientLibrary/Utils/RulesCatalog.cs
@@ -1,0 +1,12 @@
+using System.Text.Json.Serialization;
+
+namespace FabInspector.ClientLibrary.Utils
+{
+    public sealed class RulesCatalog
+    {
+        public string Name { get; set; } = "Rules Catalog";
+
+        [JsonPropertyName("ruleSets")]
+        public List<RuleSetReference> RuleSets { get; set; } = [];
+    }
+}

--- a/FabInspector.ClientLibrary/Utils/RulesCatalogReader.cs
+++ b/FabInspector.ClientLibrary/Utils/RulesCatalogReader.cs
@@ -1,0 +1,215 @@
+using FabInspector.Core;
+using FabInspector.Core.Exceptions;
+using System.Net.Http;
+using System.Text.Json;
+
+namespace FabInspector.ClientLibrary.Utils
+{
+    internal sealed class RulesCatalogReader
+    {
+        private readonly ITokenProvider? _tokenProvider;
+        private readonly HttpClient _httpClient;
+        private readonly Action<string>? _onProgress;
+
+        public RulesCatalogReader(ITokenProvider? tokenProvider, HttpClient httpClient, Action<string>? onProgress = null)
+        {
+            _tokenProvider = tokenProvider;
+            _httpClient = httpClient;
+            _onProgress = onProgress;
+        }
+
+        public async Task<IReadOnlyList<ResolvedRuleSet>> ReadResolvedRuleSetsAsync(string catalogPath)
+        {
+            if (string.IsNullOrWhiteSpace(catalogPath))
+            {
+                throw new PBIRInspectorException("Rules catalog path cannot be empty.");
+            }
+
+            var catalog = await ReadCatalogAsync(catalogPath).ConfigureAwait(false);
+            if (catalog == null || catalog.RuleSets == null || catalog.RuleSets.Count == 0)
+            {
+                throw new PBIRInspectorException($"No ruleset references were found within rules catalog at '{catalogPath}'.");
+            }
+
+            var resolvedRuleSets = new List<ResolvedRuleSet>();
+            foreach (var reference in catalog.RuleSets)
+            {
+                if (string.IsNullOrWhiteSpace(reference.Name))
+                {
+                    throw new PBIRInspectorException($"Rules catalog '{catalogPath}' contains a ruleset with no name.");
+                }
+
+                if (string.IsNullOrWhiteSpace(reference.Path))
+                {
+                    throw new PBIRInspectorException($"Ruleset '{reference.Name}' in catalog '{catalogPath}' has an empty path.");
+                }
+
+                if (reference.Disabled)
+                {
+                    _onProgress?.Invoke($"Skipping disabled ruleset '{reference.Name}' from catalog '{catalogPath}'.");
+                    continue;
+                }
+
+                string type;
+                try
+                {
+                    type = RuleSetReference.DetectType(reference.Type, reference.Path);
+                    reference.Type = type;
+                }
+                catch (InvalidOperationException ex)
+                {
+                    throw new PBIRInspectorException($"Ruleset '{reference.Name}' in catalog '{catalogPath}' has an invalid type.", ex);
+                }
+
+                var resolvedPath = ResolveRuleSetPath(catalogPath, reference);
+                var rules = await ReadRulesFromReferenceAsync(type, resolvedPath).ConfigureAwait(false);
+                if (rules == null || rules.Rules == null || rules.Rules.Count == 0)
+                {
+                    throw new PBIRInspectorException($"No rule definitions were found in ruleset '{reference.Name}' at '{resolvedPath}'.");
+                }
+
+                resolvedRuleSets.Add(new ResolvedRuleSet
+                {
+                    Name = reference.Name,
+                    SourcePath = resolvedPath,
+                    Rules = rules
+                });
+            }
+
+            if (resolvedRuleSets.Count == 0)
+            {
+                throw new PBIRInspectorException($"All rulesets in catalog '{catalogPath}' are disabled or invalid.");
+            }
+
+            return resolvedRuleSets;
+        }
+
+        private async Task<RulesCatalog?> ReadCatalogAsync(string catalogPath)
+        {
+            try
+            {
+                if (OneLakeRulesFileDownloader.IsOneLakeDfsUrl(catalogPath))
+                {
+                    if (_tokenProvider == null)
+                    {
+                        throw new InvalidOperationException("OneLake rules catalog URL requires authentication.");
+                    }
+
+                    using var stream = await OneLakeRulesFileDownloader.DownloadFileToMemoryStreamAsync(
+                        catalogPath,
+                        _tokenProvider.Credential,
+                        onProgress: _onProgress).ConfigureAwait(false);
+
+                    return JsonUtils.Deserialise<RulesCatalog>(stream);
+                }
+
+                return JsonUtils.DeserialiseFromPath<RulesCatalog>(catalogPath);
+            }
+            catch (FileNotFoundException ex)
+            {
+                throw new PBIRInspectorException($"Rules catalog path '{catalogPath}' was not found.", ex);
+            }
+            catch (JsonException ex)
+            {
+                throw new PBIRInspectorException($"Could not deserialize rules catalog at '{catalogPath}'. Check the JSON format.", ex);
+            }
+            catch (InvalidOperationException ex) when (OneLakeRulesFileDownloader.IsOneLakeDfsUrl(catalogPath))
+            {
+                throw new PBIRInspectorException($"Could not load rules catalog from OneLake URL '{catalogPath}'.", ex);
+            }
+            catch (InvalidOperationException ex)
+            {
+                throw new PBIRInspectorException($"Rules catalog at '{catalogPath}' contains an invalid ruleset definition.", ex);
+            }
+        }
+
+        private async Task<InspectionRules?> ReadRulesFromReferenceAsync(string type, string resolvedPath)
+        {
+            return type switch
+            {
+                "onelake" => await ReadOneLakeRulesAsync(resolvedPath).ConfigureAwait(false),
+                "url" => await ReadUrlRulesAsync(resolvedPath).ConfigureAwait(false),
+                _ => JsonUtils.DeserialiseFromPath<InspectionRules>(resolvedPath)
+            };
+        }
+
+        private async Task<InspectionRules?> ReadOneLakeRulesAsync(string resolvedPath)
+        {
+            if (_tokenProvider == null)
+            {
+                throw new PBIRInspectorException(
+                    $"OneLake ruleset URL '{resolvedPath}' requires authentication. Use -authmethod interactive, azurecli, clientsecret, certificate, federatedtoken, or managedidentity.");
+            }
+
+            using var rulesStream = await OneLakeRulesFileDownloader.DownloadFileToMemoryStreamAsync(
+                resolvedPath,
+                _tokenProvider.Credential,
+                onProgress: _onProgress).ConfigureAwait(false);
+
+            return JsonUtils.Deserialise<InspectionRules>(rulesStream);
+        }
+
+        private async Task<InspectionRules?> ReadUrlRulesAsync(string resolvedPath)
+        {
+            if (!Uri.TryCreate(resolvedPath, UriKind.Absolute, out var uri)
+                || !uri.Scheme.Equals(Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new PBIRInspectorException($"Ruleset URL '{resolvedPath}' must be an absolute HTTPS URL.");
+            }
+
+            _onProgress?.Invoke($"Downloading rules file from URL '{resolvedPath}'.");
+            using var stream = await _httpClient.GetStreamAsync(uri).ConfigureAwait(false);
+            return JsonUtils.Deserialise<InspectionRules>(stream);
+        }
+
+        private static string ResolveRuleSetPath(string catalogPath, RuleSetReference reference)
+        {
+            var rawPath = reference.Path.Trim();
+
+            if (reference.Type == "onelake")
+            {
+                if (OneLakeRulesFileDownloader.IsOneLakeDfsUrl(rawPath))
+                {
+                    return rawPath;
+                }
+
+                if (OneLakeRulesFileDownloader.IsOneLakeDfsUrl(catalogPath))
+                {
+                    return CombineOneLakePath(catalogPath, rawPath);
+                }
+
+                throw new PBIRInspectorException($"Ruleset '{reference.Name}' is marked as OneLake but path '{rawPath}' is not a valid OneLake DFS URL.");
+            }
+
+            if (reference.Type == "url")
+            {
+                return rawPath;
+            }
+
+            if (Path.IsPathRooted(rawPath))
+            {
+                return rawPath;
+            }
+
+            if (Uri.TryCreate(rawPath, UriKind.Absolute, out _))
+            {
+                return rawPath;
+            }
+
+            if (OneLakeRulesFileDownloader.IsOneLakeDfsUrl(catalogPath))
+            {
+                throw new PBIRInspectorException($"Ruleset '{reference.Name}' uses a relative local path '{rawPath}', but the catalog is hosted on OneLake. Use absolute paths or OneLake URLs for remote catalogs.");
+            }
+
+            var catalogDirectory = Path.GetDirectoryName(catalogPath) ?? string.Empty;
+            return Path.GetFullPath(Path.Combine(catalogDirectory, rawPath));
+        }
+
+        private static string CombineOneLakePath(string catalogPath, string childPath)
+        {
+            var baseUri = new Uri(catalogPath);
+            var absoluteChild = new Uri(baseUri, childPath);
+            return absoluteChild.ToString();
+        }
+    }
+}

--- a/FabInspector.Core/IRuleSet.cs
+++ b/FabInspector.Core/IRuleSet.cs
@@ -1,0 +1,14 @@
+namespace FabInspector.Core
+{
+    /// <summary>
+    /// Represents a single rules set reference inside a rules catalog.
+    /// </summary>
+    public interface IRuleSet
+    {
+        string Name { get; set; }
+
+        bool Disabled { get; set; }
+
+        string Path { get; set; }
+    }
+}

--- a/FabInspector.Core/Output/TestResult.cs
+++ b/FabInspector.Core/Output/TestResult.cs
@@ -16,6 +16,10 @@ namespace FabInspector.Core.Output
 
         public string? RuleItemType { get; set; }
 
+        public string? RuleSetName { get; set; }
+
+        public string? RuleSetPath { get; set; }
+
         public string? ItemPath { get; set; }
 
         public string? ParentName { get; set; }

--- a/FabInspector.Core/Output/TestRun.cs
+++ b/FabInspector.Core/Output/TestRun.cs
@@ -5,6 +5,7 @@ namespace FabInspector.Core.Output
         public Guid Id { get; set; }
             public string? TestedFilePath { get; set; }
             public string? RulesFilePath { get; set; }
+            public string? RulesCatalogPath { get; set; }
         public DateTime CompletionTime { get; set; }
         public bool Verbose { get; set; }
             public IEnumerable<TestResult> Results { get; set; } = [];

--- a/FabInspector.Tests/CLIArgsUtilsTest.cs
+++ b/FabInspector.Tests/CLIArgsUtilsTest.cs
@@ -947,6 +947,44 @@ namespace FabInspector.Tests
                 && parsedArgs.ADOOutput);
         }
 
+        [Test]
+        public void TestCLIArgsUtilsSuccess_RulesCatalogOption()
+        {
+            string[] args = "-fabricitem fabricitempath -rulescatalog catalogPath.json".Split(" ");
+            var parsedArgs = ArgsUtils.ParseArgs(args);
+
+            Assert.That(parsedArgs.RulesCatalogPath.Equals("catalogPath.json", StringComparison.OrdinalIgnoreCase)
+                && string.IsNullOrEmpty(parsedArgs.RulesFilePath));
+        }
+
+        [Test]
+        public void TestCLIArgsUtilsThrows_RulesAndRulesCatalogTogether()
+        {
+            string[] args = "-fabricitem fabricitempath -rules rulesPath -rulescatalog catalogPath.json".Split(" ");
+
+            var ex = Assert.Throws<ArgumentNullException>(() => ArgsUtils.ParseArgs(args));
+            Assert.That(ex.Message.Contains("Exactly one of -rules or -rulescatalog must be defined"));
+        }
+
+        [Test]
+        public void TestCLIArgsUtilsThrows_NoRulesOrRulesCatalog()
+        {
+            string[] args = "-fabricitem fabricitempath".Split(" ");
+
+            var ex = Assert.Throws<ArgumentNullException>(() => ArgsUtils.ParseArgs(args));
+            Assert.That(ex.Message.Contains("Exactly one of -rules or -rulescatalog must be defined"));
+        }
+
+        [Test]
+        public void TestCLIArgsUtilsThrows_OneLakeRulesCatalogWithLocalAuth()
+        {
+            string oneLakeCatalogUrl = "https://onelake.dfs.fabric.microsoft.com/MyWorkspace/MyLakehouse.Lakehouse/Files/rules-catalog.json";
+            string[] args = $"-fabricitem fabricitempath -rulescatalog {oneLakeCatalogUrl}".Split(" ");
+
+            var ex = Assert.Throws<ArgumentException>(() => ArgsUtils.ParseArgs(args));
+            Assert.That(ex.Message.Contains("OneLake rules catalog URL requires authentication"));
+        }
+
     }
 }
 

--- a/FabInspector.Tests/Output/ConsoleResultWriterTests.cs
+++ b/FabInspector.Tests/Output/ConsoleResultWriterTests.cs
@@ -112,6 +112,25 @@ namespace FabInspector.Tests.Output
             Assert.That(itemMessages[0].ItemPath, Is.EqualTo(string.Empty));
         }
 
+        [Test]
+        public async Task WriteAsync_AlwaysPrefixesMessageWithRulesetName()
+        {
+            var results = new List<TestResult>
+            {
+                new() { RuleName = "R1", Message = "first", Pass = false, LogType = MessageTypeEnum.Error, RuleSetName = "Org baseline" },
+                new() { RuleName = "R2", Message = "second", Pass = false, LogType = MessageTypeEnum.Warning, RuleSetName = null }
+            };
+
+            var itemMessages = new List<(string ItemPath, MessageTypeEnum Type, string Message)>();
+            var context = CreateContext(results, onItemMessage: (path, type, msg) => itemMessages.Add((path, type, msg)));
+
+            var writer = new ConsoleResultWriter();
+            await writer.WriteAsync(context);
+
+            Assert.That(itemMessages[0].Message, Is.EqualTo("[Ruleset: Org baseline] first"));
+            Assert.That(itemMessages[1].Message, Is.EqualTo("[Ruleset: Unknown] second"));
+        }
+
         private static OutputContext CreateContext(
             IEnumerable<TestResult> results,
             Action<MessageTypeEnum, string>? onMessage = null,

--- a/FabInspector.Tests/RulesCatalogReaderTests.cs
+++ b/FabInspector.Tests/RulesCatalogReaderTests.cs
@@ -1,0 +1,99 @@
+using FabInspector.ClientLibrary.Utils;
+using FabInspector.Core.Exceptions;
+
+namespace FabInspector.Tests
+{
+    public class RulesCatalogReaderTests
+    {
+        [Test]
+        public async Task ReadResolvedRuleSetsAsync_LoadsEnabledRuleSetsAndSkipsDisabled()
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), "fab-inspector-tests", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tempDir);
+
+            try
+            {
+                var baseRulesPath = Path.Combine(tempDir, "base-rules.json");
+                var localRulesPath = Path.Combine(tempDir, "local-rules.json");
+                var disabledRulesPath = Path.Combine(tempDir, "disabled-rules.json");
+                var catalogPath = Path.Combine(tempDir, "rules-catalog.json");
+
+                File.WriteAllText(baseRulesPath, BuildSimpleRulesJson("Base Rule"));
+                File.WriteAllText(localRulesPath, BuildSimpleRulesJson("Local Rule"));
+                File.WriteAllText(disabledRulesPath, BuildSimpleRulesJson("Disabled Rule"));
+
+                File.WriteAllText(catalogPath, @"{
+  ""name"": ""Enterprise Catalog"",
+  ""ruleSets"": [
+    { ""name"": ""Base"", ""path"": ""base-rules.json"" },
+    { ""name"": ""Disabled"", ""path"": ""disabled-rules.json"", ""disabled"": true },
+    { ""name"": ""Local"", ""type"": ""local"", ""path"": ""local-rules.json"" }
+  ]
+}");
+
+                var reader = new RulesCatalogReader(null, new HttpClient());
+                var resolved = await reader.ReadResolvedRuleSetsAsync(catalogPath);
+
+                Assert.That(resolved.Count, Is.EqualTo(2));
+                Assert.That(resolved[0].Name, Is.EqualTo("Base"));
+                Assert.That(resolved[1].Name, Is.EqualTo("Local"));
+                Assert.That(resolved[0].SourcePath, Is.EqualTo(baseRulesPath));
+                Assert.That(resolved[1].SourcePath, Is.EqualTo(localRulesPath));
+                Assert.That(resolved.All(_ => _.Rules.Rules.Count == 1));
+            }
+            finally
+            {
+                if (Directory.Exists(tempDir))
+                {
+                    Directory.Delete(tempDir, true);
+                }
+            }
+        }
+
+        [Test]
+        public void ReadResolvedRuleSetsAsync_ThrowsForUnsupportedRuleSetType()
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), "fab-inspector-tests", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tempDir);
+
+            try
+            {
+                var catalogPath = Path.Combine(tempDir, "rules-catalog.json");
+                File.WriteAllText(catalogPath, @"{
+  ""name"": ""Enterprise Catalog"",
+  ""ruleSets"": [
+    { ""name"": ""InvalidType"", ""type"": ""blob"", ""path"": ""rules.json"" }
+  ]
+}");
+
+                var reader = new RulesCatalogReader(null, new HttpClient());
+
+                var ex = Assert.ThrowsAsync<PBIRInspectorException>(async () => await reader.ReadResolvedRuleSetsAsync(catalogPath));
+                Assert.That(ex!.Message.Contains("has an invalid type"));
+            }
+            finally
+            {
+                if (Directory.Exists(tempDir))
+                {
+                    Directory.Delete(tempDir, true);
+                }
+            }
+        }
+
+        private static string BuildSimpleRulesJson(string ruleName)
+        {
+            return $@"{{
+  ""rules"": [
+    {{
+      ""name"": ""{ruleName}"",
+      ""itemType"": ""none"",
+      ""test"": [
+        {{ ""=="": [1, 1] }},
+        true
+      ]
+    }}
+  ]
+}}";
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ Fab Inspector supports local, workspace, and OneLake-based validation workflows.
 | 3. Workspace-scoped | All/some items in a Fabric workspace | Local or OneLake | Console or JSON stored in OneLake | `interactive`, `azurecli`, [`clientsecret`](#handling-client-secrets-safely), `certificate`, `federatedtoken`, or `managedidentity` |
 | 4. Item-scoped workspace | Single item in a Fabric workspace | Local or OneLake | Console or JSON stored in OneLake | `interactive`, `azurecli`, [`clientsecret`](#handling-client-secrets-safely), `certificate`, `federatedtoken`, or `managedidentity` |
 
+Rules input can be provided either as a single rules file (`-rules`) or as a rules catalog (`-rulescatalog`) that references multiple rulesets. The two options are mutually exclusive.
+
+Rules catalog examples are available at [DocsExamples/Example-RulesCatalog.json](DocsExamples/Example-RulesCatalog.json).
+
 
 ### 1. Local Fabric item definitions + local rules + local output
 


### PR DESCRIPTION
This pull request introduces support for using a rules catalog (a collection of rulesets from multiple sources) in addition to single rules files. It refactors the test execution pipeline to resolve and execute all rulesets defined in a catalog, updates the CLI and output formats, and enhances the UI with new filtering and display options for rulesets.

**Rules Catalog Support and Execution Pipeline Refactor:**

* Added support for specifying a rules catalog via the `-rulescatalog` argument, allowing users to define and execute multiple rulesets from various sources (local, URL, OneLake). (`Args.cs`, `ArgsUtils.cs`, `Example-RulesCatalog.json`) [[1]](diffhunk://#diff-e38d9f9d3c26e3e7394a73f982ade2939fba1a45aad519a2ea8a874e8cd561a8R10-R11) [[2]](diffhunk://#diff-a80f5b810ea24f225fff0737aeeda05e1a488ead44e730a6f63c852de10304ebR16) [[3]](diffhunk://#diff-a80f5b810ea24f225fff0737aeeda05e1a488ead44e730a6f63c852de10304ebR38-R39) [[4]](diffhunk://#diff-f28e84ea6e04b12c55c7d64cfdafae4b2b062dfd304e5aa9cac3ac88c97bd1afR1-R29)
* Refactored the test execution pipeline to resolve all rulesets from the catalog and execute them, capturing the ruleset name and path in each test result. (`Main.cs`) [[1]](diffhunk://#diff-658c0e23d7782c9af97c8a469f108c35186d92621ac60757a6f8087e8eeb83ddL138-R145) [[2]](diffhunk://#diff-658c0e23d7782c9af97c8a469f108c35186d92621ac60757a6f8087e8eeb83ddL254-R247) [[3]](diffhunk://#diff-658c0e23d7782c9af97c8a469f108c35186d92621ac60757a6f8087e8eeb83ddR264-R337)

**UI and Filtering Enhancements:**

* Added a filter for ruleset name and updated the results display to show ruleset names and paths where available. (`TestRunTemplate.html`) [[1]](diffhunk://#diff-e8a4c510b28257af57f278bbebc322a40cbae698d5b8fc97d5e437f81b5b8099R71-R75) [[2]](diffhunk://#diff-e8a4c510b28257af57f278bbebc322a40cbae698d5b8fc97d5e437f81b5b8099R136-R149) [[3]](diffhunk://#diff-e8a4c510b28257af57f278bbebc322a40cbae698d5b8fc97d5e437f81b5b8099L171-R203) [[4]](diffhunk://#diff-e8a4c510b28257af57f278bbebc322a40cbae698d5b8fc97d5e437f81b5b8099R272-R307) [[5]](diffhunk://#diff-e8a4c510b28257af57f278bbebc322a40cbae698d5b8fc97d5e437f81b5b8099R476) [[6]](diffhunk://#diff-e8a4c510b28257af57f278bbebc322a40cbae698d5b8fc97d5e437f81b5b8099L480-R550)
* Improved the pass/fail filter notice for clarity. (`TestRunTemplate.html`)

**Output and Serialization Updates:**

* Updated output writers and result orchestrator to include rules catalog path and ruleset metadata in all output formats. (`Output/ConsoleResultWriter.cs`, `Output/JsonResultWriter.cs`, `Output/OutputContext.cs`, `Output/ResultOutputOrchestrator.cs`) [[1]](diffhunk://#diff-c2f57582c58a8d9c0b9d4fc1aa1dee524a2722e249e488a5137b34e0d5eaa75fL13-R15) [[2]](diffhunk://#diff-2ccc7d14022d3c8943edaa5672c99d4d9d3f623e00c70ec2a63977eb29bbb0e8R27) [[3]](diffhunk://#diff-b772b6a25151d60ae6b53eed474e6fb2bbf2f93ba2cf354116884e7cea7064d2R13) [[4]](diffhunk://#diff-541f12b6f01b5d81a0084bd0a879a56a3439c57e6997522ed3013f4264260770R69)

**Documentation and Example Files:**

* Added an example rules catalog JSON file to illustrate the new feature. (`Example-RulesCatalog.json`)

These changes provide more flexible and scalable rule management, better traceability of test results to their source, and improved user experience in both the CLI and UI.