### PR TITLE
Mcp server tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -400,4 +400,5 @@ publish-test/
 /.github/copilot-instructions.md
 /.vscode/settings.json
 /.my-scripts/
+/.my-copilot-cli-prompts/
 THIRD-PARTY-NOTICES.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,34 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [3.4.0] - 2026-06-29
+
+### Added
+- Avalonia UI desktop project with macOS support, alongside macOS support for CLI builds.
+- New `discover_rules` MCP tool with enhanced rule applicability filtering and a `rulesCatalogPath` parameter for `Inspect`/`DiscoverRules`.
+- New example rules for union operations, variable library validation, workspace naming conventions, report structure checks, and themeable properties.
+- Set intersect operator and corresponding rule.
+
+### Changed
+- Refactored `MainWindow` layout to use a `TabControl` for Inputs and Outputs sections.
+- Refactored `Inspect` and `DiscoverRules` methods to include input validation.
+- Refactored `ExampleRules` structure and updated documentation references.
+- Revamped documentation structure and accuracy; clarified output formats, rules parameters, and authentication usage with OneLake URLs.
+
+### Fixed
+- Avalonia UI build issues and resolution of relative static file paths.
+- `FileTextSearchCountRule` now works on non-local files, not just local ones.
+- Cross-platform tests now resolve assets and paths correctly.
+- Case sensitivity in documentation paths.
+- Markdown links and operator name mismatch (renamed `intersect` to `intersection`).
+
+### Removed
+- Authentication requirement checks for rules in CLI argument parsing.
+- README/Docs link check step from the CI workflow.
+- Unnecessary timeout values in scanner API rules.
+
+[3.4.0]: https://github.com/NatVanG/fab-inspector/compare/v3.3.0...v3.4.0

--- a/FabInspector.CLI/FabInspectorTools.cs
+++ b/FabInspector.CLI/FabInspectorTools.cs
@@ -73,4 +73,27 @@ public class FabInspectorTools
 
         return JsonSerializer.Serialize(testRun, new JsonSerializerOptions { WriteIndented = true });
     }
+
+    [McpServerTool(Name = "discover_rules"), Description("Discover applicable Fabric Inspector guardrails for a Power BI / Fabric item and return planning metadata as JSON.")]
+    public async Task<string> DiscoverRules(
+        [Description("Path to a local folder containing Fabric item definitions (e.g. .pbip, .Report folder), or a Fabric item GUID when used with fabricWorkspaceId.")] string fabricItem,
+        [Description("Path to the rules file (JSON) or a OneLake DFS URL pointing to the rules file.")] string rules,
+        [Description("Optional comma-separated rule tags. When provided, returns rules containing any matching tag.")] string tags = "",
+        [Description("Authentication method. Valid: local, interactive, azurecli. Default: local.")] string authMethod = "local",
+        [Description("Fabric workspace ID (GUID). Requires authentication.")] string? fabricWorkspaceId = null)
+    {
+        var args = new Args
+        {
+            FabricItem = fabricItem,
+            RulesFilePath = rules,
+            AuthMethod = authMethod,
+            FabricWorkspaceId = fabricWorkspaceId,
+            OutputPath = string.Empty,
+            FormatsString = string.Empty
+        };
+
+        var discoveredRules = await FabInspector.ClientLibrary.Main.DiscoverRulesAsync(args, tags);
+
+        return JsonSerializer.Serialize(discoveredRules, new JsonSerializerOptions { WriteIndented = true });
+    }
 }

--- a/FabInspector.CLI/FabInspectorTools.cs
+++ b/FabInspector.CLI/FabInspectorTools.cs
@@ -52,7 +52,7 @@ public class FabInspectorTools
         [Description("Path to the rules file (JSON) or a OneLake DFS URL pointing to the rules file. Provide exactly one of 'rules' or 'rulesCatalogPath'.")] string? rules = null,
         [Description("Path to the rules catalog file (JSON) or a OneLake DFS URL pointing to the rules catalog. Provide exactly one of 'rules' or 'rulesCatalogPath'.")] string? rulesCatalogPath = null,
         [Description("Optional comma-separated rule tags. When provided, returns rules containing any matching tag.")] string tags = "",
-        [Description("Authentication method. Valid: local, interactive, azurecli. Default: local.")] string authMethod = "local",
+        [Description("Authentication method to retrieve rules or rules catalog file from OneLake if a remote OneLake URL is provided, default is local. Valid: local, interactive, azurecli. Default: local.")] string authMethod = "local",
         [Description("Fabric workspace ID (GUID). Requires authentication.")] string? fabricWorkspaceId = null)
     {
         ValidateRulesInput(rules, rulesCatalogPath);

--- a/FabInspector.CLI/FabInspectorTools.cs
+++ b/FabInspector.CLI/FabInspectorTools.cs
@@ -17,51 +17,23 @@ public class FabInspectorTools
         _pageRenderer = pageRenderer;
         _registries = registries;
     }
-
-    //[McpServerTool(Name = "inspect"), Description("Run Fabric Inspector rules against a Power BI / Fabric item and return structured inspection results as JSON.")]
-    //public async Task<string> Inspect(
-    //    [Description("Path to a local folder containing Fabric item definitions (e.g. .pbip, .Report folder), or a Fabric item GUID when used with fabricWorkspaceId.")] string fabricItem,
-    //    [Description("Path to the rules file (JSON) or a OneLake DFS URL pointing to the rules file.")] string rules,
-    //    [Description("Enable verbose output to include passing results. Default: false.")] bool verbose = false,
-    //    [Description("Enable parallel rule processing. Not supported with remote authentication. Default: false.")] bool parallel = false,
-    //    [Description("Authentication method. Valid: local, interactive, azurecli, clientsecret, certificate, federatedtoken, managedidentity. Default: local.")] string authMethod = "local",
-    //    [Description("Azure tenant ID. Required for clientsecret, certificate, and federatedtoken auth methods.")] string? tenantId = null,
-    //    [Description("Azure AD application (client) ID. Required for clientsecret, certificate, and federatedtoken auth methods.")] string? clientId = null,
-    //    [Description("Azure AD client secret. Required for clientsecret auth method.")] string? clientSecret = null,
-    //    [Description("Fabric workspace ID (GUID). Requires authentication.")] string? fabricWorkspaceId = null)
-    //{
-    //    var args = new Args
-    //    {
-    //        FabricItem = fabricItem,
-    //        RulesFilePath = rules,
-    //        VerboseString = verbose.ToString(),
-    //        ParallelString = parallel.ToString(),
-    //        AuthMethod = authMethod,
-    //        TenantId = tenantId ?? Environment.GetEnvironmentVariable("FABRIC_TENANT_ID"),
-    //        ClientId = clientId ?? Environment.GetEnvironmentVariable("FABRIC_CLIENT_ID"),
-    //        ClientSecret = clientSecret ?? Environment.GetEnvironmentVariable("FABRIC_CLIENT_SECRET"),
-    //        FabricWorkspaceId = fabricWorkspaceId,
-    //        OutputPath = string.Empty,
-    //        FormatsString = string.Empty
-    //    };
-
-    //    var testRun = await FabInspector.ClientLibrary.Main.RunAndReturnResultsAsync(args, _pageRenderer, _registries);
-
-    //    return JsonSerializer.Serialize(testRun, new JsonSerializerOptions { WriteIndented = true });
-    //}
-
+    
     [McpServerTool(Name = "inspect"), Description("Run Fabric Inspector rules against a Power BI / Fabric item and return structured inspection results as JSON.")]
     public async Task<string> Inspect(
         [Description("Path to a local folder containing Fabric item definitions (e.g. .pbip, .Report folder), or a Fabric item GUID when used with fabricWorkspaceId.")] string fabricItem,
-        [Description("Path to the rules file (JSON) or a OneLake DFS URL pointing to the rules file.")] string rules,
+        [Description("Path to the rules file (JSON) or a OneLake DFS URL pointing to the rules file. Provide exactly one of 'rules' or 'rulesCatalogPath'.")] string? rules = null,
+        [Description("Path to the rules catalog file (JSON) or a OneLake DFS URL pointing to the rules catalog. Provide exactly one of 'rules' or 'rulesCatalogPath'.")] string? rulesCatalogPath = null,
         [Description("Enable verbose output to include passing results. Default: false.")] bool verbose = false,
         [Description("Authentication method. Valid: local, interactive, azurecli. Default: local.")] string authMethod = "local",
         [Description("Fabric workspace ID (GUID). Requires authentication.")] string? fabricWorkspaceId = null)
     {
+        ValidateRulesInput(rules, rulesCatalogPath);
+
         var args = new Args
         {
             FabricItem = fabricItem,
-            RulesFilePath = rules,
+            RulesFilePath = rules ?? string.Empty,
+            RulesCatalogPath = rulesCatalogPath ?? string.Empty,
             VerboseString = verbose.ToString(),
             AuthMethod = authMethod,
             FabricWorkspaceId = fabricWorkspaceId,
@@ -77,15 +49,19 @@ public class FabInspectorTools
     [McpServerTool(Name = "discover_rules"), Description("Discover applicable Fabric Inspector guardrails for a Power BI / Fabric item and return planning metadata as JSON.")]
     public async Task<string> DiscoverRules(
         [Description("Path to a local folder containing Fabric item definitions (e.g. .pbip, .Report folder), or a Fabric item GUID when used with fabricWorkspaceId.")] string fabricItem,
-        [Description("Path to the rules file (JSON) or a OneLake DFS URL pointing to the rules file.")] string rules,
+        [Description("Path to the rules file (JSON) or a OneLake DFS URL pointing to the rules file. Provide exactly one of 'rules' or 'rulesCatalogPath'.")] string? rules = null,
+        [Description("Path to the rules catalog file (JSON) or a OneLake DFS URL pointing to the rules catalog. Provide exactly one of 'rules' or 'rulesCatalogPath'.")] string? rulesCatalogPath = null,
         [Description("Optional comma-separated rule tags. When provided, returns rules containing any matching tag.")] string tags = "",
         [Description("Authentication method. Valid: local, interactive, azurecli. Default: local.")] string authMethod = "local",
         [Description("Fabric workspace ID (GUID). Requires authentication.")] string? fabricWorkspaceId = null)
     {
+        ValidateRulesInput(rules, rulesCatalogPath);
+
         var args = new Args
         {
             FabricItem = fabricItem,
-            RulesFilePath = rules,
+            RulesFilePath = rules ?? string.Empty,
+            RulesCatalogPath = rulesCatalogPath ?? string.Empty,
             AuthMethod = authMethod,
             FabricWorkspaceId = fabricWorkspaceId,
             OutputPath = string.Empty,
@@ -95,5 +71,16 @@ public class FabInspectorTools
         var discoveredRules = await FabInspector.ClientLibrary.Main.DiscoverRulesAsync(args, tags);
 
         return JsonSerializer.Serialize(discoveredRules, new JsonSerializerOptions { WriteIndented = true });
+    }
+
+    private static void ValidateRulesInput(string? rules, string? rulesCatalogPath)
+    {
+        var hasRules = !string.IsNullOrWhiteSpace(rules);
+        var hasRulesCatalog = !string.IsNullOrWhiteSpace(rulesCatalogPath);
+
+        if (hasRules == hasRulesCatalog)
+        {
+            throw new ArgumentException("Exactly one of 'rules' or 'rulesCatalogPath' must be provided.");
+        }
     }
 }

--- a/FabInspector.ClientLibrary/InspectionEngine.cs
+++ b/FabInspector.ClientLibrary/InspectionEngine.cs
@@ -5,6 +5,7 @@ using FabInspector.Core;
 using FabInspector.Core.Inspection;
 using FabInspector.Core.Output;
 using System.Net.Http;
+using System.Text.Json.Nodes;
 
 namespace FabInspector.ClientLibrary
 {
@@ -182,6 +183,40 @@ namespace FabInspector.ClientLibrary
             };
         }
 
+        /// <summary>
+        /// Resolves applicable rules for the provided item/workspace context without executing tests
+        /// and returns agent-oriented planning metadata.
+        /// </summary>
+        public async Task<DiscoverRulesResponse> DiscoverRulesAsync(Args args, string? tags)
+        {
+            _args = args;
+
+            if (args.AuthMethod != "local")
+            {
+                await AuthenticateAsync(args).ConfigureAwait(false);
+            }
+
+            var resolvedRuleSets = await ResolveRuleSetsAsync(args).ConfigureAwait(false);
+            var fileSystem = await CreateFileSystemAsync().ConfigureAwait(false);
+
+            var targetItemTypes = await ResolveTargetItemTypesAsync(fileSystem).ConfigureAwait(false);
+            var requestedTags = ParseTags(tags);
+
+            var discoveredRules = resolvedRuleSets
+                .SelectMany(ruleSet => ProjectDiscoverableRules(ruleSet, targetItemTypes, requestedTags))
+                .ToList();
+
+            return new DiscoverRulesResponse
+            {
+                GeneratedAt = DateTime.UtcNow,
+                FabricItem = args.FabricItem,
+                RulesFilePath = args.RulesFilePath,
+                RulesCatalogPath = args.RulesCatalogPath,
+                TargetItemTypes = targetItemTypes.OrderBy(itemType => itemType, StringComparer.OrdinalIgnoreCase).ToList(),
+                Rules = discoveredRules
+            };
+        }
+
         private async Task AuthenticateAsync(Args args)
         {
             TokenCredential credential;
@@ -282,15 +317,8 @@ namespace FabInspector.ClientLibrary
 
         internal static IEnumerable<string>? GetScopedItemTypes(IEnumerable<ResolvedRuleSet> resolvedRuleSets)
         {
-            var scopedItemTypes = resolvedRuleSets
-                .SelectMany(ruleSet => ruleSet.Rules.Rules)
-                .SelectMany(rule => (rule.ItemType ?? string.Empty)
-                    .Split('|', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
-                .Where(itemType => !string.IsNullOrWhiteSpace(itemType))
-                .Distinct(StringComparer.OrdinalIgnoreCase)
-                .ToList();
-
-            return scopedItemTypes.Count == 0 ? null : scopedItemTypes;
+            return RuleApplicabilityService.GetScopedItemTypes(
+                resolvedRuleSets.SelectMany(ruleSet => ruleSet.Rules.Rules));
         }
 
         private async Task<IReadOnlyList<ResolvedRuleSet>> ResolveRuleSetsAsync(Args args)
@@ -312,6 +340,209 @@ namespace FabInspector.ClientLibrary
                     Rules = rules
                 }
             };
+        }
+
+        private static HashSet<string> ParseTags(string? tags)
+        {
+            if (string.IsNullOrWhiteSpace(tags))
+            {
+                return new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            }
+
+            return tags
+                .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .Where(tag => !string.IsNullOrWhiteSpace(tag))
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        }
+
+        private static IEnumerable<DiscoverRuleMetadata> ProjectDiscoverableRules(ResolvedRuleSet ruleSet, HashSet<string> targetItemTypes, HashSet<string> requestedTags)
+        {
+            foreach (var rule in RuleApplicabilityService.FilterDisabledRules(ruleSet.Rules.Rules))
+            {
+                if (!RuleApplicabilityService.TryDescribeInclusionReason(rule, targetItemTypes, out var inclusionReason))
+                {
+                    continue;
+                }
+
+                if (!RuleApplicabilityService.MatchesTags(rule, requestedTags))
+                {
+                    continue;
+                }
+
+                var operatorsUsed = ExtractOperatorsUsed(rule.Test.Logic);
+                yield return new DiscoverRuleMetadata
+                {
+                    RuleId = rule.Id,
+                    Name = rule.Name,
+                    Description = rule.Description,
+                    Severity = NormalizeSeverity(rule.LogType),
+                    ItemTypes = RuleApplicabilityService.SplitItemTypes(rule.ItemType),
+                    Tags = (rule.Tags ?? []).ToList(),
+                    SourcePath = ruleSet.SourcePath,
+                    RuleSetName = ruleSet.Name,
+                    RequiresAuth = operatorsUsed.Any(OperatorRequiresAuth),
+                    Test = new DiscoverRuleTestMetadata
+                    {
+                        Logic = rule.Test.Logic,
+                        Data = rule.Test.Data,
+                        Expected = rule.Test.Expected
+                    },
+                    PartScope = new DiscoverRulePartScopeHint
+                    {
+                        Part = rule.Part,
+                        PathErrorWhenNoMatch = rule.PathErrorWhenNoMatch,
+                        AppliesToRootPart = string.IsNullOrWhiteSpace(rule.Part)
+                    },
+                    InclusionReason = AppendTagReason(inclusionReason, requestedTags),
+                    GuidanceSummary = BuildGuidanceSummary(rule)
+                };
+            }
+        }
+
+        private static string NormalizeSeverity(string? logType)
+        {
+            return string.IsNullOrWhiteSpace(logType) ? "warning" : logType.Trim().ToLowerInvariant();
+        }
+
+        private static string AppendTagReason(string inclusionReason, HashSet<string> requestedTags)
+        {
+            if (requestedTags.Count == 0)
+            {
+                return inclusionReason;
+            }
+
+            return $"{inclusionReason} Rule also matched requested tags '{string.Join(", ", requestedTags.OrderBy(tag => tag, StringComparer.OrdinalIgnoreCase))}'.";
+        }
+
+        private static string BuildGuidanceSummary(Rule rule)
+        {
+            var scope = string.IsNullOrWhiteSpace(rule.Part) ? "root content" : $"part '{rule.Part}'";
+            return $"Validate {scope} using the provided test logic payload.";
+        }
+
+        private static List<string> ExtractOperatorsUsed(string? logicJson)
+        {
+            if (string.IsNullOrWhiteSpace(logicJson))
+            {
+                return [];
+            }
+
+            try
+            {
+                var node = JsonNode.Parse(logicJson);
+                var operators = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                CollectOperators(node, operators);
+                return operators.OrderBy(name => name, StringComparer.OrdinalIgnoreCase).ToList();
+            }
+            catch
+            {
+                return [];
+            }
+        }
+
+        private static void CollectOperators(JsonNode? node, ISet<string> operators)
+        {
+            switch (node)
+            {
+                case JsonObject obj:
+                    foreach (var property in obj)
+                    {
+                        if (!string.IsNullOrWhiteSpace(property.Key))
+                        {
+                            operators.Add(property.Key);
+                        }
+
+                        CollectOperators(property.Value, operators);
+                    }
+                    break;
+                case JsonArray array:
+                    foreach (var item in array)
+                    {
+                        CollectOperators(item, operators);
+                    }
+                    break;
+            }
+        }
+
+        private static bool OperatorRequiresAuth(string operatorName)
+        {
+            return operatorName.Equals("apiget", StringComparison.OrdinalIgnoreCase)
+                || operatorName.Equals("daxquery", StringComparison.OrdinalIgnoreCase)
+                || operatorName.Equals("dfsget", StringComparison.OrdinalIgnoreCase)
+                || operatorName.Equals("scannerapi", StringComparison.OrdinalIgnoreCase)
+                || operatorName.Equals("sqlquery", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private async Task<HashSet<string>> ResolveTargetItemTypesAsync(IFabricFileSystem fileSystem)
+        {
+            var rootPath = fileSystem.RootPath;
+            var targetItemTypes = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                "none"
+            };
+
+            if (string.IsNullOrWhiteSpace(rootPath))
+            {
+                return targetItemTypes;
+            }
+
+            if (fileSystem.DirectoryExists(rootPath))
+            {
+                var fabricItems = fileSystem.GetFabricItems(rootPath).ToList();
+
+                if (fabricItems.Count > 0)
+                {
+                    foreach (var fabricItem in fabricItems)
+                    {
+                        if (!string.IsNullOrWhiteSpace(fabricItem.Type))
+                        {
+                            targetItemTypes.Add(fabricItem.Type);
+                            targetItemTypes.Add($"{fabricItem.Type}_deprecated");
+                        }
+                    }
+
+                    return targetItemTypes;
+                }
+
+                if (rootPath.EndsWith("definition", StringComparison.OrdinalIgnoreCase)
+                    || rootPath.EndsWith(".report", StringComparison.OrdinalIgnoreCase))
+                {
+                    targetItemTypes.Add("report_deprecated");
+                }
+
+                return targetItemTypes;
+            }
+
+            if (!fileSystem.FileExists(rootPath))
+            {
+                return targetItemTypes;
+            }
+
+            var extension = fileSystem.GetExtension(rootPath).ToLowerInvariant();
+            switch (extension)
+            {
+                case ".pbip":
+                    targetItemTypes.Add("report_deprecated");
+                    break;
+                case ".json":
+                    targetItemTypes.Add("json");
+                    break;
+            }
+
+            if (!string.IsNullOrWhiteSpace(_args?.FabricWorkspaceId) && !string.IsNullOrWhiteSpace(_args?.FabricItem))
+            {
+                var scopedItems = await Task.Run(() => fileSystem.GetFabricItems(rootPath).ToList()).ConfigureAwait(false);
+                foreach (var scopedItem in scopedItems)
+                {
+                    if (!string.IsNullOrWhiteSpace(scopedItem.Type))
+                    {
+                        targetItemTypes.Add(scopedItem.Type);
+                        targetItemTypes.Add($"{scopedItem.Type}_deprecated");
+                    }
+                }
+            }
+
+            return targetItemTypes;
         }
 
         private async Task<IEnumerable<TestResult>> ExecuteSingleRuleSetAsync(ResolvedRuleSet ruleSet, IEnumerable<JsonLogicOperatorRegistry> registries, bool parallel, IFabricFileSystem fileSystem)

--- a/FabInspector.ClientLibrary/InspectionEngine.cs
+++ b/FabInspector.ClientLibrary/InspectionEngine.cs
@@ -380,7 +380,6 @@ namespace FabInspector.ClientLibrary
                     Tags = (rule.Tags ?? []).ToList(),
                     SourcePath = ruleSet.SourcePath,
                     RuleSetName = ruleSet.Name,
-                    RequiresAuth = operatorsUsed.Any(OperatorRequiresAuth),
                     Test = new DiscoverRuleTestMetadata
                     {
                         Logic = rule.Test.Logic,
@@ -462,15 +461,6 @@ namespace FabInspector.ClientLibrary
                     }
                     break;
             }
-        }
-
-        private static bool OperatorRequiresAuth(string operatorName)
-        {
-            return operatorName.Equals("apiget", StringComparison.OrdinalIgnoreCase)
-                || operatorName.Equals("daxquery", StringComparison.OrdinalIgnoreCase)
-                || operatorName.Equals("dfsget", StringComparison.OrdinalIgnoreCase)
-                || operatorName.Equals("scannerapi", StringComparison.OrdinalIgnoreCase)
-                || operatorName.Equals("sqlquery", StringComparison.OrdinalIgnoreCase);
         }
 
         private async Task<HashSet<string>> ResolveTargetItemTypesAsync(IFabricFileSystem fileSystem)

--- a/FabInspector.ClientLibrary/Main.cs
+++ b/FabInspector.ClientLibrary/Main.cs
@@ -107,6 +107,26 @@ namespace FabInspector.ClientLibrary
         }
 
         /// <summary>
+        /// Resolves applicable rules without executing tests and returns
+        /// planning metadata for agent workflows.
+        /// </summary>
+        public static async Task<DiscoverRulesResponse> DiscoverRulesAsync(Args args, string? tags)
+        {
+            _args = args;
+
+            var engine = new InspectionEngine(_httpClient);
+            using var hook = HookEngine(engine);
+            try
+            {
+                return await engine.DiscoverRulesAsync(args, tags).ConfigureAwait(false);
+            }
+            finally
+            {
+                _tokenProvider = engine.TokenProvider ?? _tokenProvider;
+            }
+        }
+
+        /// <summary>
         /// Overload that accepts a pre-built <see cref="ITokenProvider"/> (e.g. a delegated
         /// per-user token provider from a Blazor / ASP.NET host). Skips the
         /// <see cref="FabricAuthenticationHelper"/>-based credential construction entirely

--- a/FabInspector.Core/FabricLocalFileSystem.cs
+++ b/FabInspector.Core/FabricLocalFileSystem.cs
@@ -69,7 +69,7 @@ namespace FabInspector.Core
             {
                 foreach (var platformFile in platformFiles)
                 {
-                    JsonNode? platformNode = JsonNode.Parse(this.ReadAllBytes(platformFile));
+                    JsonNode? platformNode = JsonNode.Parse(this.ReadAllText(platformFile));
                     if (platformNode == null)
                     {
                         //TODO: raise error but continue

--- a/FabInspector.Core/InspectionRules.cs
+++ b/FabInspector.Core/InspectionRules.cs
@@ -22,6 +22,8 @@ namespace FabInspector.Core
 
         public string? Description { get; set; }
 
+        public List<string>? Tags { get; set; }
+
         public bool Disabled { get; set; }
 
         public string? LogType { get; set; }

--- a/FabInspector.Core/Inspector.cs
+++ b/FabInspector.Core/Inspector.cs
@@ -66,7 +66,7 @@ namespace FabInspector.Core
         public List<TestResult> Inspect()
         {
             var fileSystemPath = _fileSystem.RootPath;
-            var rules = _inspectionRules.Rules.Where(_ => !_.Disabled);
+            var rules = RuleApplicabilityService.FilterDisabledRules(_inspectionRules.Rules);
             var testResults = new List<TestResult>();
 
             if (rules != null && rules.Any())
@@ -189,11 +189,15 @@ namespace FabInspector.Core
 
             if (type.Equals("*"))
             {
-                rulesFilteredByItemType = rules.Where(_ => _.ItemType.Contains('|') || _.ItemType.Equals("*"));
+                rulesFilteredByItemType = rules.Where(rule => RuleApplicabilityService
+                    .SplitItemTypes(rule.ItemType)
+                    .Any(itemType => itemType.Equals("*", StringComparison.OrdinalIgnoreCase)));
             }
             else
             {
-                rulesFilteredByItemType = rules.Where(_ => _.ItemType.Equals(type, StringComparison.InvariantCultureIgnoreCase));
+                rulesFilteredByItemType = rules.Where(rule => RuleApplicabilityService
+                    .SplitItemTypes(rule.ItemType)
+                    .Any(itemType => itemType.Equals(type, StringComparison.OrdinalIgnoreCase)));
             }
 
             if (rulesFilteredByItemType == null || !rulesFilteredByItemType.Any())
@@ -209,15 +213,22 @@ namespace FabInspector.Core
 
         private void RunDeprecatedRulesByItemType(List<TestResult> testResults, IEnumerable<Rule> rules, string type, string fileSystemPath)
         {
-            const string DEPRECATED_SUFFIX = "_deprecated";
-            var deprecatedRules = rules.Where(_ => _.ItemType.Contains(DEPRECATED_SUFFIX, StringComparison.InvariantCultureIgnoreCase));
-            var rulesFilteredByItemType = deprecatedRules.Where(_ => _.ItemType.Replace(DEPRECATED_SUFFIX, string.Empty).Equals(type, StringComparison.InvariantCultureIgnoreCase));
+            const string DeprecatedSuffix = "_deprecated";
+            var targetTypes = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { type };
+            var rulesFilteredByItemType = rules.Where(rule =>
+                RuleApplicabilityService.SplitItemTypes(rule.ItemType)
+                    .Any(itemType => itemType.EndsWith(DeprecatedSuffix, StringComparison.OrdinalIgnoreCase))
+                && RuleApplicabilityService.IsApplicableToTargetItemTypes(rule, targetTypes));
 
-            IPartQuery partQuery = PartQueryFactory.CreatePartQuery(string.Concat(type, DEPRECATED_SUFFIX), fileSystemPath, _fileSystem);
+            if (!rulesFilteredByItemType.Any())
+            {
+                return;
+            }
+
+            IPartQuery partQuery = PartQueryFactory.CreatePartQuery(string.Concat(type, DeprecatedSuffix), fileSystemPath, _fileSystem);
 
             RunRules(testResults, rulesFilteredByItemType, partQuery);
         }
-
 
         private void RunRules(List<TestResult> testResults, IEnumerable<Rule> rules, IPartQuery partQuery)
         {

--- a/FabInspector.Core/Output/DiscoverRulesResponse.cs
+++ b/FabInspector.Core/Output/DiscoverRulesResponse.cs
@@ -1,0 +1,66 @@
+namespace FabInspector.Core.Output
+{
+    public sealed class DiscoverRulesResponse
+    {
+        public string SchemaVersion { get; set; } = "1";
+
+        public DateTime GeneratedAt { get; set; } = DateTime.UtcNow;
+
+        public string? FabricItem { get; set; }
+
+        public string? RulesFilePath { get; set; }
+
+        public string? RulesCatalogPath { get; set; }
+
+        public IReadOnlyList<string> TargetItemTypes { get; set; } = [];
+
+        public IReadOnlyList<DiscoverRuleMetadata> Rules { get; set; } = [];
+    }
+
+    public sealed class DiscoverRuleMetadata
+    {
+        public string? RuleId { get; set; }
+
+        public required string Name { get; set; }
+
+        public string? Description { get; set; }
+
+        public string Severity { get; set; } = "warning";
+
+        public IReadOnlyList<string> ItemTypes { get; set; } = [];
+
+        public IReadOnlyList<string> Tags { get; set; } = [];
+
+        public string? SourcePath { get; set; }
+
+        public string? RuleSetName { get; set; }
+
+        public bool RequiresAuth { get; set; }
+
+        public DiscoverRuleTestMetadata Test { get; set; } = new();
+
+        public DiscoverRulePartScopeHint PartScope { get; set; } = new();
+
+        public required string InclusionReason { get; set; }
+
+        public required string GuidanceSummary { get; set; }
+    }
+
+    public sealed class DiscoverRuleTestMetadata
+    {
+        public string Logic { get; set; } = string.Empty;
+
+        public System.Text.Json.Nodes.JsonNode? Data { get; set; }
+
+        public System.Text.Json.Nodes.JsonNode? Expected { get; set; }
+    }
+
+    public sealed class DiscoverRulePartScopeHint
+    {
+        public string? Part { get; set; }
+
+        public bool PathErrorWhenNoMatch { get; set; }
+
+        public bool AppliesToRootPart { get; set; }
+    }
+}

--- a/FabInspector.Core/Output/DiscoverRulesResponse.cs
+++ b/FabInspector.Core/Output/DiscoverRulesResponse.cs
@@ -35,8 +35,6 @@ namespace FabInspector.Core.Output
 
         public string? RuleSetName { get; set; }
 
-        public bool RequiresAuth { get; set; }
-
         public DiscoverRuleTestMetadata Test { get; set; } = new();
 
         public DiscoverRulePartScopeHint PartScope { get; set; } = new();

--- a/FabInspector.Core/RuleApplicabilityService.cs
+++ b/FabInspector.Core/RuleApplicabilityService.cs
@@ -1,0 +1,93 @@
+namespace FabInspector.Core
+{
+    public static class RuleApplicabilityService
+    {
+        private const string DeprecatedSuffix = "_deprecated";
+
+        public static IEnumerable<Rule> FilterDisabledRules(IEnumerable<Rule> rules)
+        {
+            return rules.Where(rule => !rule.Disabled);
+        }
+
+        public static IEnumerable<string>? GetScopedItemTypes(IEnumerable<Rule> rules)
+        {
+            var scopedItemTypes = rules
+                .SelectMany(rule => SplitItemTypes(rule.ItemType))
+                .Where(itemType => !string.IsNullOrWhiteSpace(itemType))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            return scopedItemTypes.Count == 0 ? null : scopedItemTypes;
+        }
+
+        public static bool MatchesTags(Rule rule, HashSet<string> requestedTags)
+        {
+            if (requestedTags.Count == 0)
+            {
+                return true;
+            }
+
+            if (rule.Tags == null || rule.Tags.Count == 0)
+            {
+                return false;
+            }
+
+            return rule.Tags.Any(tag => requestedTags.Contains(tag));
+        }
+
+        public static bool IsApplicableToTargetItemTypes(Rule rule, IReadOnlySet<string> targetItemTypes)
+        {
+            return TryDescribeInclusionReason(rule, targetItemTypes, out _);
+        }
+
+        public static bool TryDescribeInclusionReason(Rule rule, IReadOnlySet<string> targetItemTypes, out string inclusionReason)
+        {
+            var itemTypes = SplitItemTypes(rule.ItemType).ToList();
+
+            if (itemTypes.Count == 0)
+            {
+                inclusionReason = "Rule has no item type constraint.";
+                return false;
+            }
+
+            if (itemTypes.Any(itemType => itemType.Equals("*", StringComparison.OrdinalIgnoreCase)))
+            {
+                inclusionReason = "Rule applies to all item types via wildcard '*'.";
+                return true;
+            }
+
+            foreach (var itemType in itemTypes)
+            {
+                if (targetItemTypes.Contains(itemType))
+                {
+                    inclusionReason = itemTypes.Count == 1
+                        ? $"Rule matches explicit item type '{itemType}'."
+                        : $"Rule matches item type '{itemType}' from union '{rule.ItemType}'.";
+                    return true;
+                }
+
+                if (itemType.EndsWith(DeprecatedSuffix, StringComparison.OrdinalIgnoreCase))
+                {
+                    var normalized = itemType[..^DeprecatedSuffix.Length];
+                    if (targetItemTypes.Contains(normalized))
+                    {
+                        inclusionReason = $"Rule matches deprecated item type '{itemType}' via target type '{normalized}'.";
+                        return true;
+                    }
+                }
+            }
+
+            inclusionReason = $"Rule item types '{rule.ItemType}' do not match target item types '{string.Join(", ", targetItemTypes)}'.";
+            return false;
+        }
+
+        public static IReadOnlyList<string> SplitItemTypes(string? itemType)
+        {
+            return (itemType ?? string.Empty)
+                .Split('|', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .Where(value => !string.IsNullOrWhiteSpace(value))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+        }
+    }
+}

--- a/FabInspector.Tests/CLIArgsUtilsTest.cs
+++ b/FabInspector.Tests/CLIArgsUtilsTest.cs
@@ -142,37 +142,7 @@ namespace FabInspector.Tests
 
             Assert.That(parsedArgs.RulesFilePath.Equals("rulesPath", StringComparison.OrdinalIgnoreCase));
         }
-
-        [Test]
-        public void TestCLIArgsUtilsRulesCatalogWithOneLakeRuleSetRequiresAuth()
-        {
-            var tempDir = Path.Combine(Path.GetTempPath(), "fab-inspector-tests", Guid.NewGuid().ToString("N"));
-            Directory.CreateDirectory(tempDir);
-
-            try
-            {
-                var catalogPath = Path.Combine(tempDir, "rules-catalog.json");
-                File.WriteAllText(catalogPath, @"{
-  ""name"": ""Enterprise Catalog"",
-  ""ruleSets"": [
-    { ""name"": ""Org baseline"", ""type"": ""onelake"", ""path"": ""https://onelake.dfs.fabric.microsoft.com/YourWorkspace/YourLakehouse.Lakehouse/Files/rules/org-baseline.json"" }
-  ]
-}");
-
-                string[] args = $"-pbipreport path -rulescatalog {catalogPath} -authmethod local".Split(" ");
-
-                var ex = Assert.Throws<ArgumentException>(() => ArgsUtils.ParseArgs(args));
-                Assert.That(ex!.Message.Contains("OneLake rules catalog URL requires authentication"));
-            }
-            finally
-            {
-                if (Directory.Exists(tempDir))
-                {
-                    Directory.Delete(tempDir, true);
-                }
-            }
-        }
-
+        
         [Test]
         public void TestCLIArgsUtilsFormats()
         {

--- a/FabInspector.Tests/DiRefactorTests.cs
+++ b/FabInspector.Tests/DiRefactorTests.cs
@@ -167,6 +167,143 @@ public class DiRefactorTests
     }
 
     [Test]
+    public async Task InspectionEngine_DiscoverRulesAsync_FiltersByApplicabilityAndDisabled()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "fab-inspector-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+
+        var itemDir = Path.Combine(tempDir, "Sales.Report");
+        Directory.CreateDirectory(itemDir);
+        File.WriteAllText(Path.Combine(itemDir, ".platform"), "{\"metadata\":{\"type\":\"Report\",\"displayName\":\"Sales\"}}", Encoding.UTF8);
+
+        var rulesPath = Path.Combine(tempDir, "discover-rules.json");
+        File.WriteAllText(rulesPath, BuildDiscoverRulesJson(), Encoding.UTF8);
+
+        try
+        {
+            var args = new Args
+            {
+                FabricItem = itemDir,
+                RulesFilePath = rulesPath,
+                AuthMethod = "local"
+            };
+
+            var engine = new InspectionEngine();
+            var discovered = await engine.DiscoverRulesAsync(args, tags: string.Empty);
+
+            Assert.That(discovered.Rules.Select(_ => _.Name), Is.EquivalentTo(new[]
+            {
+                "None Rule",
+                "Report Rule",
+                "Multi Rule"
+            }));
+
+            Assert.That(discovered.SchemaVersion, Is.EqualTo("1"));
+            Assert.That(discovered.TargetItemTypes, Does.Contain("none"));
+            Assert.That(discovered.TargetItemTypes, Does.Contain("Report").IgnoreCase);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                Directory.Delete(tempDir, true);
+            }
+        }
+    }
+
+    [Test]
+    public async Task InspectionEngine_DiscoverRulesAsync_FiltersByAnyTagCaseInsensitive()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "fab-inspector-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+
+        var itemDir = Path.Combine(tempDir, "Sales.Report");
+        Directory.CreateDirectory(itemDir);
+        File.WriteAllText(Path.Combine(itemDir, ".platform"), "{\"metadata\":{\"type\":\"Report\",\"displayName\":\"Sales\"}}", Encoding.UTF8);
+
+        var rulesPath = Path.Combine(tempDir, "discover-rules.json");
+        File.WriteAllText(rulesPath, BuildDiscoverRulesJson(), Encoding.UTF8);
+
+        try
+        {
+            var args = new Args
+            {
+                FabricItem = itemDir,
+                RulesFilePath = rulesPath,
+                AuthMethod = "local"
+            };
+
+            var engine = new InspectionEngine();
+            var discovered = await engine.DiscoverRulesAsync(args, tags: "governance, PERFORMANCE");
+
+            Assert.That(discovered.Rules.Select(_ => _.Name), Is.EquivalentTo(new[]
+            {
+                "Report Rule",
+                "Multi Rule"
+            }));
+
+            Assert.That(discovered.Rules.All(_ => _.InclusionReason.Contains("matched requested tags", StringComparison.OrdinalIgnoreCase)), Is.True);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                Directory.Delete(tempDir, true);
+            }
+        }
+    }
+
+    [Test]
+    public async Task InspectionEngine_DiscoverRulesAsync_ReturnsMetadataFieldsForOperatorsAndProvenance()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "fab-inspector-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+
+        var itemDir = Path.Combine(tempDir, "Sales.Report");
+        Directory.CreateDirectory(itemDir);
+        File.WriteAllText(Path.Combine(itemDir, ".platform"), "{\"metadata\":{\"type\":\"Report\",\"displayName\":\"Sales\"}}", Encoding.UTF8);
+
+        var rulesPath = Path.Combine(tempDir, "discover-rules-metadata.json");
+        File.WriteAllText(rulesPath, BuildDiscoverRulesJsonWithRemoteOperator(), Encoding.UTF8);
+
+        try
+        {
+            var args = new Args
+            {
+                FabricItem = itemDir,
+                RulesFilePath = rulesPath,
+                AuthMethod = "local"
+            };
+
+            var engine = new InspectionEngine();
+            var discovered = await engine.DiscoverRulesAsync(args, tags: string.Empty);
+
+            Assert.That(discovered.Rules, Has.Count.EqualTo(1));
+
+            var rule = discovered.Rules.Single();
+            Assert.That(rule.RuleSetName, Is.EqualTo("Rules"));
+            Assert.That(rule.SourcePath, Is.EqualTo(rulesPath));
+            Assert.That(rule.RequiresAuth, Is.True);
+            Assert.That(rule.Test.Logic, Does.Contain("apiget"));
+            Assert.That(rule.Test.Logic, Does.Contain("\"==\""));
+            Assert.That(rule.Test.Logic, Does.Contain("\"var\""));
+            Assert.That(rule.Test.Data? ["expectedValue"]?.ToString(), Is.EqualTo("stub"));
+            Assert.That(rule.Test.Expected?.GetValue<bool>(), Is.True);
+            Assert.That(rule.PartScope.Part, Is.EqualTo("definition/pages"));
+            Assert.That(rule.PartScope.AppliesToRootPart, Is.False);
+            Assert.That(rule.GuidanceSummary, Does.Contain("definition/pages"));
+            Assert.That(rule.InclusionReason.ToLowerInvariant(), Does.Contain("explicit item type 'report'"));
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                Directory.Delete(tempDir, true);
+            }
+        }
+    }
+
+    [Test]
     public async Task InspectionEngine_RunAndReturnResultsAsync_IsolatesPerRunStateAcrossConcurrentEngines()
     {
         var registries = new[]
@@ -273,6 +410,73 @@ public class DiRefactorTests
         var path = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}_{suffix}_rules.json");
         File.WriteAllText(path, content, Encoding.UTF8);
         return path;
+    }
+
+        private static string BuildDiscoverRulesJson()
+        {
+                return """
+{
+    "rules": [
+        {
+            "name": "None Rule",
+            "itemType": "none",
+            "test": [ { "==": [1, 1] }, true ]
+        },
+        {
+            "name": "Report Rule",
+            "itemType": "report",
+            "tags": ["governance", "security"],
+            "test": [ { "==": [1, 1] }, true ]
+        },
+        {
+            "name": "Disabled Report Rule",
+            "itemType": "report",
+            "disabled": true,
+            "test": [ { "==": [1, 1] }, true ]
+        },
+        {
+            "name": "Json Rule",
+            "itemType": "json",
+            "tags": ["ops"],
+            "test": [ { "==": [1, 1] }, true ]
+        },
+        {
+            "name": "Multi Rule",
+            "itemType": "report|json",
+            "tags": ["performance"],
+            "test": [ { "==": [1, 1] }, true ]
+        }
+    ]
+}
+""";
+        }
+
+    private static string BuildDiscoverRulesJsonWithRemoteOperator()
+    {
+        return """
+{
+    "rules": [
+        {
+            "id": "RemoteReportRule",
+            "name": "Remote Report Rule",
+            "description": "Uses apiget for metadata validation",
+            "itemType": "report",
+            "part": "definition/pages",
+            "logType": "error",
+            "test": [
+                {
+                    "==": [
+                        { "apiget": ["https://api.fabric.microsoft.com/v1/workspaces"] },
+                        { "var": "expectedValue" }
+                    ]
+                },
+                { "expectedValue": "stub" },
+                true
+            ]
+        }
+    ]
+}
+""";
     }
 
     private static HttpClient CreateHttpClient(params HttpResponseMessage[] responses)

--- a/FabInspector.Tests/DiRefactorTests.cs
+++ b/FabInspector.Tests/DiRefactorTests.cs
@@ -283,7 +283,6 @@ public class DiRefactorTests
             var rule = discovered.Rules.Single();
             Assert.That(rule.RuleSetName, Is.EqualTo("Rules"));
             Assert.That(rule.SourcePath, Is.EqualTo(rulesPath));
-            Assert.That(rule.RequiresAuth, Is.True);
             Assert.That(rule.Test.Logic, Does.Contain("apiget"));
             Assert.That(rule.Test.Logic, Does.Contain("\"==\""));
             Assert.That(rule.Test.Logic, Does.Contain("\"var\""));

--- a/FabInspector.Tests/FabInspector.Tests.csproj
+++ b/FabInspector.Tests/FabInspector.Tests.csproj
@@ -43,6 +43,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\FabInspector.AvaloniaUI\FabInspector.AvaloniaUI.csproj" />
+    <ProjectReference Include="..\FabInspector.CLI\FabInspector.CLI.csproj" />
     <ProjectReference Include="..\FabInspector.ImageLibrary\FabInspector.ImageLibrary.csproj" />
     <ProjectReference Include="..\FabInspector.Core\FabInspector.Core.csproj" />
     <ProjectReference Include="..\FabInspector.WinImageLibrary\FabInspector.WinImageLibrary.csproj" />

--- a/FabInspector.Tests/FabInspectorToolsTests.cs
+++ b/FabInspector.Tests/FabInspectorToolsTests.cs
@@ -1,0 +1,299 @@
+using System.Text;
+using System.Text.Json;
+using FabInspector.ClientLibrary.Utils;
+using FabInspector.Core;
+using FabInspector.Core.Output;
+
+namespace FabInspector.Tests;
+
+[TestFixture]
+[NonParallelizable]
+public class FabInspectorToolsTests
+{
+    [Test]
+    public void Inspect_Throws_WhenRulesInputsAreMissing()
+    {
+        var sut = CreateSut();
+
+        var ex = Assert.ThrowsAsync<ArgumentException>(async () =>
+            await sut.Inspect(fabricItem: "C:/fake/item"));
+
+        Assert.That(ex, Is.Not.Null);
+        Assert.That(ex!.Message, Does.Contain("Exactly one of 'rules' or 'rulesCatalogPath' must be provided."));
+    }
+
+    [Test]
+    public void DiscoverRules_Throws_WhenBothRulesInputsAreProvided()
+    {
+        var sut = CreateSut();
+
+        var ex = Assert.ThrowsAsync<ArgumentException>(async () =>
+            await sut.DiscoverRules(
+                fabricItem: "C:/fake/item",
+                rules: "rules.json",
+                rulesCatalogPath: "rules-catalog.json"));
+
+        Assert.That(ex, Is.Not.Null);
+        Assert.That(ex!.Message, Does.Contain("Exactly one of 'rules' or 'rulesCatalogPath' must be provided."));
+    }
+
+    [Test]
+    public async Task Inspect_ReturnsSerializedTestRunJson()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "fab-inspector-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+
+        var itemDir = Path.Combine(tempDir, "Sales.Report");
+        Directory.CreateDirectory(itemDir);
+        File.WriteAllText(Path.Combine(itemDir, ".platform"), "{\"metadata\":{\"type\":\"Report\",\"displayName\":\"Sales\"}}", Encoding.UTF8);
+
+        var rulesPath = Path.Combine(tempDir, "inspect-rules.json");
+        File.WriteAllText(rulesPath, BuildInspectRulesJson(), Encoding.UTF8);
+
+        try
+        {
+            var sut = CreateSut();
+
+            var json = await sut.Inspect(
+                fabricItem: itemDir,
+                rules: rulesPath,
+                verbose: true,
+                authMethod: "local");
+
+            var testRun = JsonSerializer.Deserialize<TestRun>(json);
+
+            Assert.That(testRun, Is.Not.Null);
+            Assert.That(testRun!.TestedFilePath, Is.EqualTo(itemDir));
+            Assert.That(testRun.RulesFilePath, Is.EqualTo(rulesPath));
+            Assert.That(testRun.Results, Is.Not.Null);
+            Assert.That(testRun.Results.Any(), Is.True);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                Directory.Delete(tempDir, true);
+            }
+        }
+    }
+
+    [Test]
+    public async Task DiscoverRules_ReturnsSerializedDiscoverRulesJson()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "fab-inspector-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+
+        var itemDir = Path.Combine(tempDir, "Sales.Report");
+        Directory.CreateDirectory(itemDir);
+        File.WriteAllText(Path.Combine(itemDir, ".platform"), "{\"metadata\":{\"type\":\"Report\",\"displayName\":\"Sales\"}}", Encoding.UTF8);
+
+        var rulesPath = Path.Combine(tempDir, "discover-rules.json");
+        File.WriteAllText(rulesPath, BuildDiscoverRulesJson(), Encoding.UTF8);
+
+        try
+        {
+            var sut = CreateSut();
+
+            var json = await sut.DiscoverRules(
+                fabricItem: itemDir,
+                rules: rulesPath,
+                tags: "governance",
+                authMethod: "local");
+
+            var discovered = JsonSerializer.Deserialize<DiscoverRulesResponse>(json);
+
+            Assert.That(discovered, Is.Not.Null);
+            Assert.That(discovered!.FabricItem, Is.EqualTo(itemDir));
+            Assert.That(discovered.RulesFilePath, Is.EqualTo(rulesPath));
+            Assert.That(discovered.Rules.Any(rule => string.Equals(rule.Name, "Report Rule", StringComparison.Ordinal)), Is.True);
+            Assert.That(discovered.Rules.Any(rule => string.Equals(rule.Name, "Json Rule", StringComparison.Ordinal)), Is.False);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                Directory.Delete(tempDir, true);
+            }
+        }
+    }
+
+    [Test]
+    public void JsonUtils_DeserialiseFromPath_DeserialisesRuleTagsAsStringList()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "fab-inspector-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+
+        var rulesPath = Path.Combine(tempDir, "discover-rules.json");
+        File.WriteAllText(rulesPath, BuildDiscoverRulesJson(), Encoding.UTF8);
+
+        try
+        {
+            var rules = JsonUtils.DeserialiseFromPath<InspectionRules>(rulesPath);
+
+            Assert.That(rules, Is.Not.Null);
+
+            var reportRule = rules!.Rules.Single(rule => string.Equals(rule.Name, "Report Rule", StringComparison.Ordinal));
+
+            Assert.That(reportRule.Tags, Is.EqualTo(new[] { "governance", "security" }));
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                Directory.Delete(tempDir, true);
+            }
+        }
+    }
+
+    [Test]
+    public async Task Inspect_WithRulesCatalogPath_ReturnsSerializedTestRunJson()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "fab-inspector-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+
+        var itemDir = Path.Combine(tempDir, "Sales.Report");
+        Directory.CreateDirectory(itemDir);
+        File.WriteAllText(Path.Combine(itemDir, ".platform"), "{\"metadata\":{\"type\":\"Report\",\"displayName\":\"Sales\"}}", Encoding.UTF8);
+
+        var rulesPath = Path.Combine(tempDir, "inspect-catalog-rules.json");
+        File.WriteAllText(rulesPath, BuildInspectRulesJson(), Encoding.UTF8);
+
+        var catalogPath = Path.Combine(tempDir, "rules-catalog.json");
+        File.WriteAllText(catalogPath, BuildRulesCatalogJson("Inspect Catalog", "inspect-catalog-rules.json"), Encoding.UTF8);
+
+        try
+        {
+            var sut = CreateSut();
+
+            var json = await sut.Inspect(
+                fabricItem: itemDir,
+                rulesCatalogPath: catalogPath,
+                verbose: true,
+                authMethod: "local");
+
+            var testRun = JsonSerializer.Deserialize<TestRun>(json);
+
+            Assert.That(testRun, Is.Not.Null);
+            Assert.That(testRun!.TestedFilePath, Is.EqualTo(itemDir));
+            Assert.That(testRun.RulesCatalogPath, Is.EqualTo(catalogPath));
+            Assert.That(testRun.Results, Is.Not.Null);
+            Assert.That(testRun.Results.Any(), Is.True);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                Directory.Delete(tempDir, true);
+            }
+        }
+    }
+
+    [Test]
+    public async Task DiscoverRules_WithRulesCatalogPath_ReturnsSerializedDiscoverRulesJson()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "fab-inspector-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+
+        var itemDir = Path.Combine(tempDir, "Sales.Report");
+        Directory.CreateDirectory(itemDir);
+        File.WriteAllText(Path.Combine(itemDir, ".platform"), "{\"metadata\":{\"type\":\"Report\",\"displayName\":\"Sales\"}}", Encoding.UTF8);
+
+        var rulesPath = Path.Combine(tempDir, "discover-catalog-rules.json");
+        File.WriteAllText(rulesPath, BuildDiscoverRulesJson(), Encoding.UTF8);
+
+        var catalogPath = Path.Combine(tempDir, "rules-catalog.json");
+        File.WriteAllText(catalogPath, BuildRulesCatalogJson("Discover Catalog", "discover-catalog-rules.json"), Encoding.UTF8);
+
+        try
+        {
+            var sut = CreateSut();
+
+            var json = await sut.DiscoverRules(
+                fabricItem: itemDir,
+                rulesCatalogPath: catalogPath,
+                tags: "governance",
+                authMethod: "local");
+
+            var discovered = JsonSerializer.Deserialize<DiscoverRulesResponse>(json);
+
+            Assert.That(discovered, Is.Not.Null);
+            Assert.That(discovered!.FabricItem, Is.EqualTo(itemDir));
+            Assert.That(discovered.RulesCatalogPath, Is.EqualTo(catalogPath));
+            Assert.That(discovered.Rules.Any(rule => string.Equals(rule.Name, "Report Rule", StringComparison.Ordinal)), Is.True);
+            Assert.That(discovered.Rules.Any(rule => string.Equals(rule.Name, "Json Rule", StringComparison.Ordinal)), Is.False);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                Directory.Delete(tempDir, true);
+            }
+        }
+    }
+
+    private static FabInspectorTools CreateSut()
+    {
+        return new FabInspectorTools(new NoOpPageRenderer(), []);
+    }
+
+    private static string BuildInspectRulesJson()
+    {
+        return """
+{
+  "rules": [
+    {
+      "name": "Always True",
+      "itemType": "none",
+      "test": [ { "==": [1, 1] }, true ]
+    }
+  ]
+}
+""";
+    }
+
+    private static string BuildDiscoverRulesJson()
+    {
+        return """
+{
+  "rules": [
+    {
+      "name": "Report Rule",
+      "itemType": "report",
+      "tags": ["governance", "security"],
+      "test": [ { "==": [1, 1] }, true ]
+    },
+    {
+      "name": "Json Rule",
+      "itemType": "json",
+      "tags": ["ops"],
+      "test": [ { "==": [1, 1] }, true ]
+    }
+  ]
+}
+""";
+    }
+
+        private static string BuildRulesCatalogJson(string ruleSetName, string relativeRulesPath)
+        {
+                return $$"""
+{
+    "name": "Test Catalog",
+    "ruleSets": [
+        { "name": "{{ruleSetName}}", "path": "{{relativeRulesPath}}" }
+    ]
+}
+""";
+        }
+
+    private sealed class NoOpPageRenderer : IReportPageWireframeRenderer
+    {
+        public void DrawReportPages(IEnumerable<TestResult> fieldMapResults, IEnumerable<TestResult> testResults, string outputDir)
+        {
+        }
+
+        public string ConvertBitmapToBase64(string bitmapPath)
+        {
+            return string.Empty;
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Beyond artifact structure, Fab Inspector can also inspect:
 - **Tenant and capacity configurations** — validate tenant posture against your governance policies through API operators
 - **Data-based checks** — use DAX query and T-SQL query operators as rule conditions to enforce data quality, semantic model correctness, and lakehouse health
 
-Outputs can be written as Console, JSON, HTML, ADO, or GitHub formats.
+Outputs can be written as Console, JSON, HTML, ADO, or GitHub formats or combined e.g. "GitHub,JSON"
 
 ## Quick Start
 
@@ -47,16 +47,22 @@ The cross-platform `FabInspector.AvaloniaUI` desktop application lets you run in
 Local mode:
 
 ```bash
-fab-inspector -fabricitem "C:\Files\Sales.Report" -rules ".\Files\Base-rules.json" -formats "Console,JSON"
+fab-inspector -fabricitem "C:\Files\Sales.Report" -rules ".\Files\Base-rules.json" -formats Console
 ```
 
 Workspace mode (with interactive auth):
 
 ```bash
-fab-inspector -fabricworkspace "<workspace-guid>" -rules ".\Files\Base-rules.json" -authmethod interactive -formats "Console,JSON"
+fab-inspector -fabricworkspace "<workspace-guid>" -rules ".\Files\Base-rules.json" -authmethod interactive -formats Console
 ```
 
-Show CLI options:
+Workspace mode scoped to a Fabric item (with azurecli auth):
+
+```bash
+fab-inspector -fabricworkspace "<workspace-guid>" -fabricitem "<item-guid>" -rules ".\Files\Base-rules.json" -authmethod azurecli -formats Console
+```
+
+Show all CLI options:
 
 ```bash
 fab-inspector -help
@@ -73,7 +79,7 @@ Release binaries for the CLI and GUI are published at: https://github.com/NatVan
 | [Usage Scenarios](docs/usage-scenarios.md) | Common local, CI/CD, workspace, and hybrid validation patterns |
 | [GUI Reference](docs/gui-reference.md) | Cross-platform Avalonia desktop application walkthrough |
 | [CLI Reference](docs/cli-reference.md) | Full CLI parameters, auth options, and command examples |
-| [Rules Guide](docs/rules-guide.md) | Rule schema, test logic, and patching guidance |
+| [Rules Guide](docs/rules-guide.md) | Rule schema and test logic |
 | [Operators Overview](docs/operators-overview.md) | When to use Ric vs FabInspector operators |
 | [Examples Index](docs/examples-index.md) | Catalog of rule files in ExampleRules by use case |
 | [Ric Operators](docs/Ric-Operators.md) | Local/query/transformation/file-system operators |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -77,7 +77,6 @@ Optional, false by default. If false then only rule violations are shown; if tru
 Optional, false by default. If true, rules are split across available processors and run in parallel before results are merged.
 
 > **Warnings when using `-parallel true`:**
-> - If rules use `applyPatch`, avoid parallel patching of the same part/file because writes can conflict and become last-writer-wins.
 > - Rules that call remote APIs (`apiget`, `dfsget`, `daxquery`, `sqlquery`, `scannerapi`) may hit service throttling/rate limits sooner under parallel fan-out.
 > - `scannerapi` polls for up to 5 minutes per request; parallel use with this operator is not recommended.
 
@@ -161,7 +160,8 @@ This is useful in agentic workflows where an agent is creating or editing Fabric
 | Parameter | Required | Description |
 |---|---|---|
 | `fabricItem` | Yes | Local path to a Fabric item/folder, or a Fabric item GUID when used with `fabricWorkspaceId`. |
-| `rules` | Yes | Local rules JSON path or OneLake DFS URL. |
+| `rules` | Conditional | Local rules JSON path or OneLake DFS URL. Provide exactly one of `rules` or `rulesCatalogPath`. |
+| `rulesCatalogPath` | Conditional | Local rules catalog JSON path or OneLake DFS URL. Provide exactly one of `rules` or `rulesCatalogPath`. |
 | `verbose` | No | `false` by default. If `true`, passing and failing rule results are included. |
 | `authMethod` | No | `local` (default), `interactive`, or `azurecli`. |
 | `fabricWorkspaceId` | No | Fabric workspace GUID. Required for workspace/item GUID scenarios. |
@@ -193,6 +193,19 @@ This is useful in agentic workflows where an agent is creating or editing Fabric
 }
 ```
 
+**Local folder + rules catalog:**
+```json
+{
+	"tool": "inspect",
+	"arguments": {
+		"fabricItem": "C:\\Files\\Sales.Report",
+		"rulesCatalogPath": "C:\\Rules\\rules-catalog.json",
+		"verbose": true,
+		"authMethod": "local"
+	}
+}
+```
+
 **Workspace item GUID + interactive auth:**
 ```json
 {
@@ -213,7 +226,8 @@ This is useful in agentic workflows where an agent is creating or editing Fabric
 | Parameter | Required | Description |
 |---|---|---|
 | `fabricItem` | Yes | Local path to a Fabric item/folder, or a Fabric item GUID when used with `fabricWorkspaceId`. |
-| `rules` | Yes | Local rules JSON path or OneLake DFS URL. |
+| `rules` | Conditional | Local rules JSON path or OneLake DFS URL. Provide exactly one of `rules` or `rulesCatalogPath`. |
+| `rulesCatalogPath` | Conditional | Local rules catalog JSON path or OneLake DFS URL. Provide exactly one of `rules` or `rulesCatalogPath`. |
 | `tags` | No | Comma-separated tags. When supplied, rules are filtered by any matching tag (case-insensitive). |
 | `authMethod` | No | `local` (default), `interactive`, or `azurecli`. |
 | `fabricWorkspaceId` | No | Fabric workspace GUID. Required for workspace/item GUID scenarios. |
@@ -239,6 +253,19 @@ This is useful in agentic workflows where an agent is creating or editing Fabric
 	"arguments": {
 		"fabricItem": "C:\\Files\\Sales.Report",
 		"rules": "C:\\Rules\\Base-rules.json",
+		"tags": "governance,performance",
+		"authMethod": "local"
+	}
+}
+```
+
+**Local folder + rules catalog (tag-filtered):**
+```json
+{
+	"tool": "discover_rules",
+	"arguments": {
+		"fabricItem": "C:\\Files\\Sales.Report",
+		"rulesCatalogPath": "C:\\Rules\\rules-catalog.json",
 		"tags": "governance,performance",
 		"authMethod": "local"
 	}
@@ -278,7 +305,7 @@ Each returned rule includes planning-oriented fields such as:
 
 - `ruleId`, `name`, `description`, `severity`
 - `itemTypes`, `tags`, `ruleSetName`, `sourcePath`
-- `requiresAuth`, `test` (`logic`, `data`, `expected`)
+- `test` (`logic`, `data`, `expected`)
 - `partScope`, `inclusionReason`, `guidanceSummary`
 
 Use `discover_rules` as the pre-flight planning step and `inspect` as the deterministic enforcement step.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -151,6 +151,140 @@ fab-inspector -help
 
 ---
 
+## MCP Tool Examples
+
+Use the `discover_rules` MCP tool to return applicable guardrail metadata before running `inspect`.
+This is useful in agentic workflows where an agent is creating or editing Fabric items and needs rule context, scope, and remote-operator hints up front.
+
+### inspect parameters
+
+| Parameter | Required | Description |
+|---|---|---|
+| `fabricItem` | Yes | Local path to a Fabric item/folder, or a Fabric item GUID when used with `fabricWorkspaceId`. |
+| `rules` | Yes | Local rules JSON path or OneLake DFS URL. |
+| `verbose` | No | `false` by default. If `true`, passing and failing rule results are included. |
+| `authMethod` | No | `local` (default), `interactive`, or `azurecli`. |
+| `fabricWorkspaceId` | No | Fabric workspace GUID. Required for workspace/item GUID scenarios. |
+
+### inspect examples
+
+**Local folder + local rules:**
+```json
+{
+	"tool": "inspect",
+	"arguments": {
+		"fabricItem": "C:\\Files\\Sales.Report",
+		"rules": "C:\\Rules\\Base-rules.json",
+		"authMethod": "local"
+	}
+}
+```
+
+**Local folder + local rules (verbose results):**
+```json
+{
+	"tool": "inspect",
+	"arguments": {
+		"fabricItem": "C:\\Files\\Sales.Report",
+		"rules": "C:\\Rules\\Base-rules.json",
+		"verbose": true,
+		"authMethod": "local"
+	}
+}
+```
+
+**Workspace item GUID + interactive auth:**
+```json
+{
+	"tool": "inspect",
+	"arguments": {
+		"fabricWorkspaceId": "12345678-1234-1234-1234-123456789abc",
+		"fabricItem": "87654321-4321-4321-4321-cba987654321",
+		"rules": "./Rules/ci-rules.json",
+		"authMethod": "interactive"
+	}
+}
+```
+
+`inspect` returns structured inspection run results as JSON, including run metadata and rule evaluation outcomes.
+
+### discover_rules parameters
+
+| Parameter | Required | Description |
+|---|---|---|
+| `fabricItem` | Yes | Local path to a Fabric item/folder, or a Fabric item GUID when used with `fabricWorkspaceId`. |
+| `rules` | Yes | Local rules JSON path or OneLake DFS URL. |
+| `tags` | No | Comma-separated tags. When supplied, rules are filtered by any matching tag (case-insensitive). |
+| `authMethod` | No | `local` (default), `interactive`, or `azurecli`. |
+| `fabricWorkspaceId` | No | Fabric workspace GUID. Required for workspace/item GUID scenarios. |
+
+### discover_rules examples
+
+**Local folder + local rules (no tag filter):**
+```json
+{
+	"tool": "discover_rules",
+	"arguments": {
+		"fabricItem": "C:\\Files\\Sales.Report",
+		"rules": "C:\\Rules\\Base-rules.json",
+		"authMethod": "local"
+	}
+}
+```
+
+**Local folder + local rules (tag-filtered):**
+```json
+{
+	"tool": "discover_rules",
+	"arguments": {
+		"fabricItem": "C:\\Files\\Sales.Report",
+		"rules": "C:\\Rules\\Base-rules.json",
+		"tags": "governance,performance",
+		"authMethod": "local"
+	}
+}
+```
+
+**Workspace item GUID + interactive auth:**
+```json
+{
+	"tool": "discover_rules",
+	"arguments": {
+		"fabricWorkspaceId": "12345678-1234-1234-1234-123456789abc",
+		"fabricItem": "87654321-4321-4321-4321-cba987654321",
+		"rules": "./Rules/ci-rules.json",
+		"authMethod": "interactive"
+	}
+}
+```
+
+**Workspace with OneLake-hosted rules + Azure CLI auth:**
+```json
+{
+	"tool": "discover_rules",
+	"arguments": {
+		"fabricWorkspaceId": "12345678-1234-1234-1234-123456789abc",
+		"fabricItem": "87654321-4321-4321-4321-cba987654321",
+		"rules": "https://onelake.dfs.fabric.microsoft.com/<workspace>/<lakehouse>/Files/rules/rules.json",
+		"tags": "security",
+		"authMethod": "azurecli"
+	}
+}
+```
+
+`discover_rules` returns a schema-versioned JSON object containing matching, non-disabled rule metadata using the same rules-loading/auth behavior as `inspect`.
+
+Each returned rule includes planning-oriented fields such as:
+
+- `ruleId`, `name`, `description`, `severity`
+- `itemTypes`, `tags`, `ruleSetName`, `sourcePath`
+- `requiresAuth`, `test` (`logic`, `data`, `expected`)
+- `partScope`, `inclusionReason`, `guidanceSummary`
+
+Use `discover_rules` as the pre-flight planning step and `inspect` as the deterministic enforcement step.
+
+---
+
 ## Handling client secrets safely
 
 Treat client secrets as credentials, not configuration. Do not commit them to source control, paste real values into checked-in scripts, or expose them in build logs, screenshots, or shared chat threads.


### PR DESCRIPTION
This pull request introduces several major features and improvements, most notably the addition of a new Avalonia UI desktop project with macOS support, a new `discover_rules` MCP tool for rule discovery and applicability filtering, and significant enhancements to rule input validation and documentation. There are also important bug fixes and code refactoring for better maintainability and cross-platform support.

**New Features:**

* Added Avalonia UI desktop project with macOS support and enabled macOS support for CLI builds.
* Introduced a new `discover_rules` MCP tool with enhanced rule applicability filtering and support for the `rulesCatalogPath` parameter in both `Inspect` and `DiscoverRules` methods. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R34) [[2]](diffhunk://#diff-26dc8770c5ac792931e426b89bc4f6c7701c11bb5a8e670422a5bf1a1b6bf39cR48-R85) [[3]](diffhunk://#diff-34fab9bd0a9ca15aae757fcfe233908ac99007d4a12755e36983f23721c0acf1R186-R219) [[4]](diffhunk://#diff-658c0e23d7782c9af97c8a469f108c35186d92621ac60757a6f8087e8eeb83ddR109-R128)
* Added new example rules for union operations, variable library validation, workspace naming conventions, report structure checks, and themeable properties, as well as a set intersection operator and corresponding rule.

**API and CLI Improvements:**

* Refactored the `Inspect` and new `DiscoverRules` MCP methods to require exactly one of `rules` or `rulesCatalogPath`, with input validation to enforce this constraint. [[1]](diffhunk://#diff-26dc8770c5ac792931e426b89bc4f6c7701c11bb5a8e670422a5bf1a1b6bf39cL21-R36) [[2]](diffhunk://#diff-26dc8770c5ac792931e426b89bc4f6c7701c11bb5a8e670422a5bf1a1b6bf39cR48-R85)
* Updated rule filtering and applicability logic, including tag-based filtering and improved item type resolution. [[1]](diffhunk://#diff-34fab9bd0a9ca15aae757fcfe233908ac99007d4a12755e36983f23721c0acf1R345-R537) [[2]](diffhunk://#diff-c12cb1e48ead2bf9f98ce6cde064ae370a16a4505c36a3054bf4af883f9ae526L69-R69) [[3]](diffhunk://#diff-c12cb1e48ead2bf9f98ce6cde064ae370a16a4505c36a3054bf4af883f9ae526L192-R200) [[4]](diffhunk://#diff-920f3169a28d84a34a5c78526226d17f85ea78a260d5ba0d3a2c2bebd10ca701R25-R26)

**Documentation and Structure:**

* Revamped documentation for improved structure and accuracy, clarified output formats, rules parameters, and authentication usage with OneLake URLs.

**Bug Fixes and Technical Improvements:**

* Fixed Avalonia UI build issues, static file path resolution, cross-platform test asset resolution, and case sensitivity in documentation paths. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R34) [[2]](diffhunk://#diff-a0702b0cb4f96648cb42b78334e586a15d2f155675f8f2d884704d0889b6d3f2L72-R72)
* Fixed `FileTextSearchCountRule` to work on non-local files and resolved markdown link and operator name mismatches.

**Removals:**

* Removed authentication requirement checks for rules in CLI argument parsing and unnecessary timeout values in scanner API rules.

These changes collectively enhance the usability, cross-platform compatibility, and extensibility of the Fabric Inspector toolset.