### PR TITLE
Fix discover rules mcp tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.5.0] - 2026-07-22
+
+### Added
+- Rule tags filtering: new `-tags` CLI option and `tags` MCP tool parameter to run only rules containing any matching tag (case-insensitive); an empty value runs all applicable rules. Matched tags are now surfaced in JSON and HTML output.
+- `fabricItemTypes` parameter for `discover_rules`, allowing rule discovery to filter by one or more Fabric item types without resolving a concrete item.
+
+### Changed
+- `DiscoverRules` now exposes an async `DiscoverRulesAsync` method and propagates the active tags filter through the inspection engine and output context.
+- Updated CLI, operators, examples, intro, and usage-scenarios documentation, including a corrected CI/CD pipeline reference link.
+
+[3.5.0]: https://github.com/NatVanG/fab-inspector/compare/v3.4.0...v3.5.0
+
 ## [3.4.0] - 2026-06-29
 
 ### Added

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <FabInspectorVersionPrefix Condition="'$(FabInspectorVersionPrefix)' == ''">3.4.0</FabInspectorVersionPrefix>
+    <FabInspectorVersionPrefix Condition="'$(FabInspectorVersionPrefix)' == ''">3.4.1</FabInspectorVersionPrefix>
     <VersionPrefix Condition="'$(VersionPrefix)' == ''">$(FabInspectorVersionPrefix)</VersionPrefix>
     <Version Condition="'$(Version)' == ''">$(VersionPrefix)</Version>
     <AssemblyVersion Condition="'$(AssemblyVersion)' == ''">$(VersionPrefix).0</AssemblyVersion>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <FabInspectorVersionPrefix Condition="'$(FabInspectorVersionPrefix)' == ''">3.4.1</FabInspectorVersionPrefix>
+    <FabInspectorVersionPrefix Condition="'$(FabInspectorVersionPrefix)' == ''">3.5.1</FabInspectorVersionPrefix>
     <VersionPrefix Condition="'$(VersionPrefix)' == ''">$(FabInspectorVersionPrefix)</VersionPrefix>
     <Version Condition="'$(Version)' == ''">$(VersionPrefix)</Version>
     <AssemblyVersion Condition="'$(AssemblyVersion)' == ''">$(VersionPrefix).0</AssemblyVersion>

--- a/ExampleRules/37-Report-base-rules.json
+++ b/ExampleRules/37-Report-base-rules.json
@@ -4,6 +4,7 @@
       "id": "REMOVE_UNUSED_CUSTOM_VISUALS",
       "name": "Remove custom visuals which are not used in the report.",
       "description": "Returns an array of custom visual names to be removed if any. To disable this rule, mark it as disabled in the base rules file.",
+      "tags": ["performance", "governance"],
       "disabled": false,
       "itemType": "Report",
       "part": "Report",
@@ -32,6 +33,7 @@
       "name": "Reduce the number of visible visuals on the page",
       "description": "Reports a test fail if the rule's maximum number of visible visuals on the page is exceeded. By default the base rules file specifies 20 as the maximum, set the paramMaxVisualsPerPage parameter to change this. To disable this rule, mark it as disabled in the base rules file.",
       "disabled": false,
+      "tags": ["accessiblity","performance"],
       "itemType": "Report",
       "part": "Pages",
       "test": [

--- a/FabInspector.CLI/FabInspectorTools.cs
+++ b/FabInspector.CLI/FabInspectorTools.cs
@@ -48,18 +48,20 @@ public class FabInspectorTools
 
     [McpServerTool(Name = "discover_rules"), Description("Discover applicable Fabric Inspector guardrails for a Power BI / Fabric item and return planning metadata as JSON.")]
     public async Task<string> DiscoverRules(
-        [Description("Path to a local folder containing Fabric item definitions (e.g. .pbip, .Report folder), or a Fabric item GUID when used with fabricWorkspaceId.")] string fabricItem,
+        [Description("Optional path to a local folder containing Fabric item definitions (e.g. .pbip, .Report folder), or a Fabric item GUID when used with fabricWorkspaceId.")] string? fabricItem = null,
+        [Description("If a fabricItem or fabricWorkspaceId is not provided then pass a list of one or more Fabric item types. When provided, discovery filters rules by matching itemType instead of resolving a concrete item.")] List<string>? fabricItemTypes = null,
         [Description("Path to the rules file (JSON) or a OneLake DFS URL pointing to the rules file. Provide exactly one of 'rules' or 'rulesCatalogPath'.")] string? rules = null,
         [Description("Path to the rules catalog file (JSON) or a OneLake DFS URL pointing to the rules catalog. Provide exactly one of 'rules' or 'rulesCatalogPath'.")] string? rulesCatalogPath = null,
         [Description("Optional comma-separated rule tags. When provided, returns rules containing any matching tag.")] string tags = "",
         [Description("Authentication method to retrieve rules or rules catalog file from OneLake if a remote OneLake URL is provided, default is local. Valid: local, interactive, azurecli. Default: local.")] string authMethod = "local",
-        [Description("Fabric workspace ID (GUID). Requires authentication.")] string? fabricWorkspaceId = null)
+        [Description("Optional Fabric workspace ID (GUID). Requires authentication.")] string? fabricWorkspaceId = null)
     {
         ValidateRulesInput(rules, rulesCatalogPath);
 
         var args = new Args
         {
             FabricItem = fabricItem,
+            FabricItemTypes = fabricItemTypes,
             RulesFilePath = rules ?? string.Empty,
             RulesCatalogPath = rulesCatalogPath ?? string.Empty,
             AuthMethod = authMethod,

--- a/FabInspector.CLI/FabInspectorTools.cs
+++ b/FabInspector.CLI/FabInspectorTools.cs
@@ -24,6 +24,7 @@ public class FabInspectorTools
         [Description("Path to the rules file (JSON) or a OneLake DFS URL pointing to the rules file. Provide exactly one of 'rules' or 'rulesCatalogPath'.")] string? rules = null,
         [Description("Path to the rules catalog file (JSON) or a OneLake DFS URL pointing to the rules catalog. Provide exactly one of 'rules' or 'rulesCatalogPath'.")] string? rulesCatalogPath = null,
         [Description("Enable verbose output to include passing results. Default: false.")] bool verbose = false,
+        [Description("Optional comma-separated rule tags. When provided, only rules containing any matching tag (case-insensitive) are run; empty runs all applicable rules.")] string tags = "",
         [Description("Authentication method. Valid: local, interactive, azurecli. Default: local.")] string authMethod = "local",
         [Description("Fabric workspace ID (GUID). Requires authentication.")] string? fabricWorkspaceId = null)
     {
@@ -35,6 +36,7 @@ public class FabInspectorTools
             RulesFilePath = rules ?? string.Empty,
             RulesCatalogPath = rulesCatalogPath ?? string.Empty,
             VerboseString = verbose.ToString(),
+            Tags = tags,
             AuthMethod = authMethod,
             FabricWorkspaceId = fabricWorkspaceId,
             OutputPath = string.Empty,
@@ -64,13 +66,14 @@ public class FabInspectorTools
             FabricItemTypes = fabricItemTypes,
             RulesFilePath = rules ?? string.Empty,
             RulesCatalogPath = rulesCatalogPath ?? string.Empty,
+            Tags = tags,
             AuthMethod = authMethod,
             FabricWorkspaceId = fabricWorkspaceId,
             OutputPath = string.Empty,
             FormatsString = string.Empty
         };
 
-        var discoveredRules = await FabInspector.ClientLibrary.Main.DiscoverRulesAsync(args, tags);
+        var discoveredRules = await FabInspector.ClientLibrary.Main.DiscoverRulesAsync(args);
 
         return JsonSerializer.Serialize(discoveredRules, new JsonSerializerOptions { WriteIndented = true });
     }

--- a/FabInspector.ClientLibrary/Files/html/TestRunTemplate.html
+++ b/FabInspector.ClientLibrary/Files/html/TestRunTemplate.html
@@ -103,6 +103,11 @@
                         </div>
 
                         <div>
+                            <label for="filterTags" class="form-label small mb-1">Tags</label>
+                            <input id="filterTags" name="tags" type="search" class="form-control form-control-sm" placeholder="Contains...">
+                        </div>
+
+                        <div>
                             <label for="filterPass" class="form-label small mb-1">Pass</label>
                             <select id="filterPass" name="pass" class="form-select form-select-sm">
                                 <option value="any" selected>Any</option>
@@ -213,6 +218,19 @@
                             "<>": "p",
                             "class": "pb-3 mb-0 small lh-sm",
                             "html": [{ "<>": "strong", "class": "d-block text-gray-dark", "text": "Verbose" }, { "text": "${Verbose}" }]
+                        }
+                    ]
+                },
+                {
+                    "<>": "div",
+                    "class": "d-flex text-body-secondary pt-3",
+                    "html": [
+                        {
+                            "<>": "p",
+                            "class": function () {
+                                return this.TagsFilter ? "pb-3 mb-0 small lh-sm" : "pb-3 mb-0 small lh-sm d-none";
+                            },
+                            "html": [{ "<>": "strong", "class": "d-block text-gray-dark", "text": "Tags Filter" }, { "text": function () { return this.TagsFilter || ""; } }]
                         }
                     ]
                 },
@@ -365,6 +383,24 @@
                                                 },
                                                 {
                                                     "<>": "p",
+                                                    "class": function () {
+                                                        return (this.Tags && this.Tags.length > 0) ? "pb-3 mb-0 small lh-sm" : "pb-3 mb-0 small lh-sm d-none";
+                                                    },
+                                                    "html": [
+                                                        {
+                                                            "<>": "strong",
+                                                            "class": "d-block text-gray-dark",
+                                                            "text": "Tags"
+                                                        },
+                                                        {
+                                                            "text": function () {
+                                                                return (this.Tags && this.Tags.length > 0) ? this.Tags.join(", ") : "";
+                                                            }
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "<>": "p",
                                                     "class": "pb-3 mb-0 small lh-sm",
                                                     "html": [
                                                         {
@@ -469,6 +505,20 @@
             return normalizeText(sourceValue).includes(expectedValue);
         }
 
+        function matchesTags(tagsArray, expectedValue) {
+            if (!expectedValue) {
+                return true;
+            }
+
+            if (!Array.isArray(tagsArray) || tagsArray.length === 0) {
+                return false;
+            }
+
+            return tagsArray.some(function (tag) {
+                return normalizeText(tag).includes(expectedValue);
+            });
+        }
+
         function getActiveFilters() {
             const passFilterDisabled = $("#filterPass").prop("disabled");
 
@@ -476,9 +526,10 @@
                 ruleSetName: normalizeText($("#filterRuleSetName").val()),
                 ruleName: normalizeText($("#filterRuleName").val()),
                 logType: $("#filterLogType").val(),
-                ruleItemType: normalizeText($("#filterRuleItemType").val()),
+                 ruleItemType: normalizeText($("#filterRuleItemType").val()),
                 itemPath: normalizeText($("#filterItemPath").val()),
                 parentDisplayName: normalizeText($("#filterParentDisplayName").val()),
+                tags: normalizeText($("#filterTags").val()),
                 pass: passFilterDisabled ? "any" : $("#filterPass").val()
             };
         }
@@ -552,6 +603,7 @@
                     && matchesContains(item.RuleItemType, filters.ruleItemType)
                     && matchesContains(item.ItemPath, filters.itemPath)
                     && matchesContains(item.ParentDisplayName, filters.parentDisplayName)
+                    && matchesTags(item.Tags, filters.tags)
                     && matchPass(item, filters.pass);
             });
 

--- a/FabInspector.ClientLibrary/InspectionEngine.cs
+++ b/FabInspector.ClientLibrary/InspectionEngine.cs
@@ -199,7 +199,12 @@ namespace FabInspector.ClientLibrary
             var resolvedRuleSets = await ResolveRuleSetsAsync(args).ConfigureAwait(false);
             var fileSystem = await CreateFileSystemAsync().ConfigureAwait(false);
 
-            var targetItemTypes = await ResolveTargetItemTypesAsync(fileSystem).ConfigureAwait(false);
+            var targetItemTypes = ParseFabricItemTypes(args.FabricItemTypes);
+            if (targetItemTypes.Count == 0)
+            {
+                targetItemTypes = await ResolveTargetItemTypesAsync(fileSystem).ConfigureAwait(false);
+            }
+
             var requestedTags = ParseTags(tags);
 
             var discoveredRules = resolvedRuleSets
@@ -352,6 +357,19 @@ namespace FabInspector.ClientLibrary
             return tags
                 .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
                 .Where(tag => !string.IsNullOrWhiteSpace(tag))
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        }
+
+        private static HashSet<string> ParseFabricItemTypes(IEnumerable<string>? fabricItemTypes)
+        {
+            if (fabricItemTypes == null)
+            {
+                return new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            }
+
+            return fabricItemTypes
+                .Where(itemType => !string.IsNullOrWhiteSpace(itemType))
+                .Select(itemType => itemType.Trim())
                 .ToHashSet(StringComparer.OrdinalIgnoreCase);
         }
 

--- a/FabInspector.ClientLibrary/InspectionEngine.cs
+++ b/FabInspector.ClientLibrary/InspectionEngine.cs
@@ -187,7 +187,7 @@ namespace FabInspector.ClientLibrary
         /// Resolves applicable rules for the provided item/workspace context without executing tests
         /// and returns agent-oriented planning metadata.
         /// </summary>
-        public async Task<DiscoverRulesResponse> DiscoverRulesAsync(Args args, string? tags)
+        public async Task<DiscoverRulesResponse> DiscoverRulesAsync(Args args)
         {
             _args = args;
 
@@ -205,7 +205,7 @@ namespace FabInspector.ClientLibrary
                 targetItemTypes = await ResolveTargetItemTypesAsync(fileSystem).ConfigureAwait(false);
             }
 
-            var requestedTags = ParseTags(tags);
+            var requestedTags = ParseTags(args.Tags);
 
             var discoveredRules = resolvedRuleSets
                 .SelectMany(ruleSet => ProjectDiscoverableRules(ruleSet, targetItemTypes, requestedTags))
@@ -291,6 +291,7 @@ namespace FabInspector.ClientLibrary
             using var holderScope = InspectionContextHolder.PushScope(inspectionContext);
 
             var resolvedRuleSets = await ResolveRuleSetsAsync(args).ConfigureAwait(false);
+            resolvedRuleSets = FilterRuleSetsByTags(resolvedRuleSets, ParseTags(args.Tags));
             var fileSystem = await CreateFileSystemAsync().ConfigureAwait(false);
             fileSystem.ScopedItemTypes = GetScopedItemTypes(resolvedRuleSets);
             var remoteFs = SubscribeToProgressEvents(fileSystem);
@@ -358,6 +359,27 @@ namespace FabInspector.ClientLibrary
                 .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
                 .Where(tag => !string.IsNullOrWhiteSpace(tag))
                 .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Filters the rules within each resolved rule set to those matching any of the
+        /// requested tags. When no tags are requested every rule is retained.
+        /// </summary>
+        private static IReadOnlyList<ResolvedRuleSet> FilterRuleSetsByTags(IReadOnlyList<ResolvedRuleSet> resolvedRuleSets, HashSet<string> requestedTags)
+        {
+            if (requestedTags.Count == 0)
+            {
+                return resolvedRuleSets;
+            }
+
+            foreach (var ruleSet in resolvedRuleSets)
+            {
+                ruleSet.Rules.Rules = ruleSet.Rules.Rules
+                    .Where(rule => RuleApplicabilityService.MatchesTags(rule, requestedTags))
+                    .ToList();
+            }
+
+            return resolvedRuleSets;
         }
 
         private static HashSet<string> ParseFabricItemTypes(IEnumerable<string>? fabricItemTypes)

--- a/FabInspector.ClientLibrary/Main.cs
+++ b/FabInspector.ClientLibrary/Main.cs
@@ -110,7 +110,7 @@ namespace FabInspector.ClientLibrary
         /// Resolves applicable rules without executing tests and returns
         /// planning metadata for agent workflows.
         /// </summary>
-        public static async Task<DiscoverRulesResponse> DiscoverRulesAsync(Args args, string? tags)
+        public static async Task<DiscoverRulesResponse> DiscoverRulesAsync(Args args)
         {
             _args = args;
 
@@ -118,7 +118,7 @@ namespace FabInspector.ClientLibrary
             using var hook = HookEngine(engine);
             try
             {
-                return await engine.DiscoverRulesAsync(args, tags).ConfigureAwait(false);
+                return await engine.DiscoverRulesAsync(args).ConfigureAwait(false);
             }
             finally
             {

--- a/FabInspector.ClientLibrary/Output/JsonResultWriter.cs
+++ b/FabInspector.ClientLibrary/Output/JsonResultWriter.cs
@@ -25,6 +25,7 @@ namespace FabInspector.ClientLibrary.Output
                 TestedFilePath = context.TestedFilePath,
                 RulesFilePath = context.RulesFilePath,
                 RulesCatalogPath = context.RulesCatalogPath,
+                TagsFilter = context.TagsFilter,
                 Verbose = context.Verbose,
                 Results = context.TestResults
             };

--- a/FabInspector.ClientLibrary/Output/OutputContext.cs
+++ b/FabInspector.ClientLibrary/Output/OutputContext.cs
@@ -11,6 +11,7 @@ namespace FabInspector.ClientLibrary.Output
         public required string TestedFilePath { get; init; }
         public string? RulesFilePath { get; init; }
         public string? RulesCatalogPath { get; init; }
+        public string? TagsFilter { get; init; }
         public bool Verbose { get; init; }
         public bool OverwriteOutput { get; init; }
         public string? FabricItem { get; init; }

--- a/FabInspector.ClientLibrary/Output/ResultOutputOrchestrator.cs
+++ b/FabInspector.ClientLibrary/Output/ResultOutputOrchestrator.cs
@@ -67,6 +67,7 @@ namespace FabInspector.ClientLibrary.Output
                     TestedFilePath = BuildTestedFilePath(),
                     RulesFilePath = _args.RulesFilePath,
                     RulesCatalogPath = _args.RulesCatalogPath,
+                    TagsFilter = _args.Tags,
                     Verbose = _args.Verbose,
                     OverwriteOutput = _args.OverwriteOutput,
                     FabricItem = _args.FabricItem,

--- a/FabInspector.ClientLibrary/Utils/Args.cs
+++ b/FabInspector.ClientLibrary/Utils/Args.cs
@@ -5,6 +5,8 @@ namespace FabInspector.ClientLibrary.Utils
     {
         public string? FabricItem { get; set; }
 
+        public List<string>? FabricItemTypes { get; set; }
+
         public string? RulesFilePath { get; set; }
 
         public string? RulesCatalogPath { get; set; }

--- a/FabInspector.ClientLibrary/Utils/Args.cs
+++ b/FabInspector.ClientLibrary/Utils/Args.cs
@@ -121,5 +121,7 @@ namespace FabInspector.ClientLibrary.Utils
         public string? FederatedToken { get; set; }
         
         public string? FabricWorkspaceId { get; set; }
+
+        public string? Tags { get; set; }
     }
 }

--- a/FabInspector.ClientLibrary/Utils/ArgsUtils.cs
+++ b/FabInspector.ClientLibrary/Utils/ArgsUtils.cs
@@ -51,6 +51,8 @@ OPTIONAL PARAMETERS:
   -verbose <true|false>           Display all results including passes (default: false)
   -parallel <true|false>          Enable parallel rule processing (default: false)
   -overwriteoutput <true|false>   Overwrite existing output (default: false)
+  -tags <tag1,tag2,...>           Comma-separated rule tags. When provided, only rules containing any
+                                  matching tag (case-insensitive) are run; empty runs all applicable rules.
 
 AUTHENTICATION PARAMETERS (use -authmethod):
   -authmethod <method>            Authentication method (default: local)
@@ -127,9 +129,9 @@ For more information, visit: https://github.com/NatVanG/fab-inspector
 
         public static Args ParseArgs(string[] args)
         {
-            const string PBIX = "-pbix", PBIP = "-pbip", PBIPREPORT = "-pbipreport", FABRICITEM = "-fabricitem", FABRICWORKSPACE = "-fabricworkspace", RULES = "-rules", RULESCATALOG = "-rulescatalog", OUTPUT = "-output", FORMATS = "-formats", VERBOSE = "-verbose", PARALLEL = "-parallel", OVERWRITEOUTPUT = "-overwriteoutput", AUTHMETHOD = "-authmethod", TENANTID = "-tenantid", CLIENTID = "-clientid", CLIENTSECRET = "-clientsecret", CERTIFICATEPATH = "-certificatepath", CERTIFICATEPASSWORD = "-certificatepassword", FEDERATEDTOKEN = "-federatedtoken", HELP = "-help";
+            const string PBIX = "-pbix", PBIP = "-pbip", PBIPREPORT = "-pbipreport", FABRICITEM = "-fabricitem", FABRICWORKSPACE = "-fabricworkspace", RULES = "-rules", RULESCATALOG = "-rulescatalog", OUTPUT = "-output", FORMATS = "-formats", VERBOSE = "-verbose", PARALLEL = "-parallel", OVERWRITEOUTPUT = "-overwriteoutput", TAGS = "-tags", AUTHMETHOD = "-authmethod", TENANTID = "-tenantid", CLIENTID = "-clientid", CLIENTSECRET = "-clientsecret", CERTIFICATEPATH = "-certificatepath", CERTIFICATEPASSWORD = "-certificatepassword", FEDERATEDTOKEN = "-federatedtoken", HELP = "-help";
             const string FALSE = "false";
-            string[] validOptions = { PBIX, PBIP, PBIPREPORT, FABRICITEM, FABRICWORKSPACE, RULES, RULESCATALOG, OUTPUT, FORMATS, VERBOSE, PARALLEL, OVERWRITEOUTPUT, AUTHMETHOD, TENANTID, CLIENTID, CLIENTSECRET, CERTIFICATEPATH, CERTIFICATEPASSWORD, FEDERATEDTOKEN, HELP };
+            string[] validOptions = { PBIX, PBIP, PBIPREPORT, FABRICITEM, FABRICWORKSPACE, RULES, RULESCATALOG, OUTPUT, FORMATS, VERBOSE, PARALLEL, OVERWRITEOUTPUT, TAGS, AUTHMETHOD, TENANTID, CLIENTID, CLIENTSECRET, CERTIFICATEPATH, CERTIFICATEPASSWORD, FEDERATEDTOKEN, HELP };
 
             int index = 0;
             int maxindex = args.Length - 2;
@@ -167,6 +169,7 @@ For more information, visit: https://github.com/NatVanG/fab-inspector
             var parallelString = dic.ContainsKey(PARALLEL) ? dic[PARALLEL] : FALSE;
             var overwriteOutput = dic.ContainsKey(OVERWRITEOUTPUT) ? dic[OVERWRITEOUTPUT] : FALSE;
             var formatsString = dic.ContainsKey(FORMATS) ? dic[FORMATS] : string.Empty;
+            var tags = dic.ContainsKey(TAGS) ? dic[TAGS] : null;
             
             // Fabric workspace parameter
             var fabricWorkspaceId = dic.ContainsKey(FABRICWORKSPACE) ? dic[FABRICWORKSPACE] : null;
@@ -278,6 +281,7 @@ For more information, visit: https://github.com/NatVanG/fab-inspector
                 VerboseString = verboseString, 
                 ParallelString = parallelString, 
                 OverwriteOutputString = overwriteOutput, 
+                Tags = tags,
                 AuthMethod = authMethod,
                 TenantId = tenantId,
                 ClientId = clientId,

--- a/FabInspector.Core/Inspector.cs
+++ b/FabInspector.Core/Inspector.cs
@@ -328,7 +328,7 @@ namespace FabInspector.Core
 
                             if (rule.PathErrorWhenNoMatch)
                             {
-                                testResults.Add(new TestResult { RuleId = rule.Id, RuleName = rule.Name, LogType = ruleLogType, RuleDescription = rule.Description, RuleItemType = rule.ItemType, ItemPath = null, ParentName = null, ParentDisplayName = "N/A", Pass = false, Message = msg, Expected = rule.Test.Expected, Actual = null });
+                                testResults.Add(new TestResult { RuleId = rule.Id, RuleName = rule.Name, LogType = ruleLogType, RuleDescription = rule.Description, RuleItemType = rule.ItemType, Tags = rule.Tags, ItemPath = null, ParentName = null, ParentDisplayName = "N/A", Pass = false, Message = msg, Expected = rule.Test.Expected, Actual = null });
                             }
                         }
                         else
@@ -354,7 +354,7 @@ namespace FabInspector.Core
                                 result = expectedResult?.IsEquivalentTo(jruleresult) ?? jruleresult is null;
 
                                 string resultString = string.Format("Rule \"{0}\" {1} with result: {2}, expected: {3}", rule.Name, result ? "PASSED" : "FAILED", actualResultString, expectedResultString);
-                                testResults.Add(new TestResult { RuleId = rule.Id, RuleName = rule.Name, LogType = ruleLogType, RuleDescription = rule.Description, RuleItemType = rule.ItemType, ItemPath = itemPath, ParentName = parentPageName, ParentDisplayName = parentPageDisplayName, Pass = result, Message = resultString, Expected = expectedResult, Actual = jruleresult });
+                                testResults.Add(new TestResult { RuleId = rule.Id, RuleName = rule.Name, LogType = ruleLogType, RuleDescription = rule.Description, RuleItemType = rule.ItemType, Tags = rule.Tags, ItemPath = itemPath, ParentName = parentPageName, ParentDisplayName = parentPageDisplayName, Pass = result, Message = resultString, Expected = expectedResult, Actual = jruleresult });
 
                                 //PATCH
                                 if (!result && rule.ApplyPatch && rule.Patch != null && rule.Patch.Ops != null)
@@ -398,7 +398,7 @@ namespace FabInspector.Core
                 }
                 catch (PBIRInspectorException e)
                 {
-                    testResults.Add(new TestResult { RuleId = rule.Id, RuleName = rule.Name, LogType = MessageTypeEnum.Error, RuleDescription = rule.Description, RuleItemType = rule.ItemType, Pass = false, Message = e.Message, Expected = rule.Test.Expected, Actual = null });
+                    testResults.Add(new TestResult { RuleId = rule.Id, RuleName = rule.Name, LogType = MessageTypeEnum.Error, RuleDescription = rule.Description, RuleItemType = rule.ItemType, Tags = rule.Tags, Pass = false, Message = e.Message, Expected = rule.Test.Expected, Actual = null });
                     continue;
                 }
 

--- a/FabInspector.Core/Output/TestResult.cs
+++ b/FabInspector.Core/Output/TestResult.cs
@@ -16,6 +16,8 @@ namespace FabInspector.Core.Output
 
         public string? RuleItemType { get; set; }
 
+        public List<string>? Tags { get; set; }
+
         public string? RuleSetName { get; set; }
 
         public string? RuleSetPath { get; set; }

--- a/FabInspector.Core/Output/TestRun.cs
+++ b/FabInspector.Core/Output/TestRun.cs
@@ -6,6 +6,7 @@ namespace FabInspector.Core.Output
             public string? TestedFilePath { get; set; }
             public string? RulesFilePath { get; set; }
             public string? RulesCatalogPath { get; set; }
+            public string? TagsFilter { get; set; }
         public DateTime CompletionTime { get; set; }
         public bool Verbose { get; set; }
             public IEnumerable<TestResult> Results { get; set; } = [];

--- a/FabInspector.Tests/CLIArgsUtilsTest.cs
+++ b/FabInspector.Tests/CLIArgsUtilsTest.cs
@@ -79,6 +79,24 @@ namespace FabInspector.Tests
         }
 
         [Test]
+        public void TestCLIArgsUtilsSuccess_TagsOption()
+        {
+            string[] args = "-fabricitem fabricitempath -rules rulesPath -tags governance,performance".Split(" ");
+            var parsedArgs = ArgsUtils.ParseArgs(args);
+
+            Assert.That(parsedArgs.Tags, Is.EqualTo("governance,performance"));
+        }
+
+        [Test]
+        public void TestCLIArgsUtilsSuccess_TagsOptionMissingIsNull()
+        {
+            string[] args = "-fabricitem fabricitempath -rules rulesPath".Split(" ");
+            var parsedArgs = ArgsUtils.ParseArgs(args);
+
+            Assert.That(parsedArgs.Tags, Is.Null);
+        }
+
+        [Test]
         public void TestCLIArgsUtilsSuccess_PBIPOption()
         {
             string[] args = "-pbip pbipPath -rules rulesPath -verbose true".Split(" ");

--- a/FabInspector.Tests/DiRefactorTests.cs
+++ b/FabInspector.Tests/DiRefactorTests.cs
@@ -189,7 +189,7 @@ public class DiRefactorTests
             };
 
             var engine = new InspectionEngine();
-            var discovered = await engine.DiscoverRulesAsync(args, tags: string.Empty);
+            var discovered = await engine.DiscoverRulesAsync(args);
 
             Assert.That(discovered.Rules.Select(_ => _.Name), Is.EquivalentTo(new[]
             {
@@ -233,8 +233,9 @@ public class DiRefactorTests
                 AuthMethod = "local"
             };
 
+            args.Tags = "governance, PERFORMANCE";
             var engine = new InspectionEngine();
-            var discovered = await engine.DiscoverRulesAsync(args, tags: "governance, PERFORMANCE");
+            var discovered = await engine.DiscoverRulesAsync(args);
 
             Assert.That(discovered.Rules.Select(_ => _.Name), Is.EquivalentTo(new[]
             {
@@ -276,7 +277,7 @@ public class DiRefactorTests
             };
 
             var engine = new InspectionEngine();
-            var discovered = await engine.DiscoverRulesAsync(args, tags: string.Empty);
+            var discovered = await engine.DiscoverRulesAsync(args);
 
             Assert.That(discovered.Rules, Has.Count.EqualTo(1));
 

--- a/FabInspector.Tests/FabInspectorToolsTests.cs
+++ b/FabInspector.Tests/FabInspectorToolsTests.cs
@@ -118,6 +118,41 @@ public class FabInspectorToolsTests
     }
 
     [Test]
+    public async Task DiscoverRules_UsesFabricItemTypesWhenFabricItemIsNotProvided()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "fab-inspector-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+
+        var rulesPath = Path.Combine(tempDir, "discover-rules.json");
+        File.WriteAllText(rulesPath, BuildDiscoverRulesJson(), Encoding.UTF8);
+
+        try
+        {
+            var sut = CreateSut();
+
+            var json = await sut.DiscoverRules(
+                fabricItemTypes: new List<string> { "report" },
+                rules: rulesPath,
+                tags: "governance",
+                authMethod: "local");
+
+            var discovered = JsonSerializer.Deserialize<DiscoverRulesResponse>(json);
+
+            Assert.That(discovered, Is.Not.Null);
+            Assert.That(discovered!.FabricItem, Is.Null);
+            Assert.That(discovered.TargetItemTypes, Is.EquivalentTo(new[] { "report" }));
+            Assert.That(discovered.Rules.Select(rule => rule.Name), Is.EquivalentTo(new[] { "Report Rule" }));
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                Directory.Delete(tempDir, true);
+            }
+        }
+    }
+
+    [Test]
     public void JsonUtils_DeserialiseFromPath_DeserialisesRuleTagsAsStringList()
     {
         var tempDir = Path.Combine(Path.GetTempPath(), "fab-inspector-tests", Guid.NewGuid().ToString("N"));

--- a/FabInspector.Tests/FabInspectorToolsTests.cs
+++ b/FabInspector.Tests/FabInspectorToolsTests.cs
@@ -78,6 +78,82 @@ public class FabInspectorToolsTests
     }
 
     [Test]
+    public async Task Inspect_WithTags_FiltersRulesAndPopulatesResultTags()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "fab-inspector-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+
+        var itemDir = Path.Combine(tempDir, "Sales.Report");
+        Directory.CreateDirectory(itemDir);
+        File.WriteAllText(Path.Combine(itemDir, ".platform"), "{\"metadata\":{\"type\":\"Report\",\"displayName\":\"Sales\"}}", Encoding.UTF8);
+
+        var rulesPath = Path.Combine(tempDir, "tagged-inspect-rules.json");
+        File.WriteAllText(rulesPath, BuildTaggedInspectRulesJson(), Encoding.UTF8);
+
+        try
+        {
+            var sut = CreateSut();
+
+            var json = await sut.Inspect(
+                fabricItem: itemDir,
+                rules: rulesPath,
+                verbose: true,
+                tags: "governance",
+                authMethod: "local");
+
+            var testRun = JsonSerializer.Deserialize<TestRun>(json);
+
+            Assert.That(testRun, Is.Not.Null);
+            Assert.That(testRun!.Results.Select(r => r.RuleName), Is.EquivalentTo(new[] { "Governance Rule" }));
+            Assert.That(testRun.Results.Single().Tags, Is.EqualTo(new[] { "governance" }));
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                Directory.Delete(tempDir, true);
+            }
+        }
+    }
+
+    [Test]
+    public async Task Inspect_WithoutTags_RunsAllApplicableRules()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "fab-inspector-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+
+        var itemDir = Path.Combine(tempDir, "Sales.Report");
+        Directory.CreateDirectory(itemDir);
+        File.WriteAllText(Path.Combine(itemDir, ".platform"), "{\"metadata\":{\"type\":\"Report\",\"displayName\":\"Sales\"}}", Encoding.UTF8);
+
+        var rulesPath = Path.Combine(tempDir, "tagged-inspect-rules.json");
+        File.WriteAllText(rulesPath, BuildTaggedInspectRulesJson(), Encoding.UTF8);
+
+        try
+        {
+            var sut = CreateSut();
+
+            var json = await sut.Inspect(
+                fabricItem: itemDir,
+                rules: rulesPath,
+                verbose: true,
+                authMethod: "local");
+
+            var testRun = JsonSerializer.Deserialize<TestRun>(json);
+
+            Assert.That(testRun, Is.Not.Null);
+            Assert.That(testRun!.Results.Select(r => r.RuleName), Is.EquivalentTo(new[] { "Governance Rule", "Performance Rule" }));
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                Directory.Delete(tempDir, true);
+            }
+        }
+    }
+
+    [Test]
     public async Task DiscoverRules_ReturnsSerializedDiscoverRulesJson()
     {
         var tempDir = Path.Combine(Path.GetTempPath(), "fab-inspector-tests", Guid.NewGuid().ToString("N"));
@@ -272,8 +348,7 @@ public class FabInspectorToolsTests
     }
 
     private static string BuildInspectRulesJson()
-    {
-        return """
+    {        return """
 {
   "rules": [
     {
@@ -281,6 +356,18 @@ public class FabInspectorToolsTests
       "itemType": "none",
       "test": [ { "==": [1, 1] }, true ]
     }
+  ]
+}
+""";
+    }
+
+    private static string BuildTaggedInspectRulesJson()
+    {
+        return """
+{
+  "rules": [
+    { "name": "Governance Rule", "itemType": "report", "tags": ["governance"], "test": [ { "==": [1, 1] }, true ] },
+    { "name": "Performance Rule", "itemType": "report", "tags": ["performance"], "test": [ { "==": [1, 1] }, true ] }
   ]
 }
 """;

--- a/FabInspector.Tests/Output/HtmlResultWriterTests.cs
+++ b/FabInspector.Tests/Output/HtmlResultWriterTests.cs
@@ -120,6 +120,20 @@ namespace FabInspector.Tests.Output
             Assert.That(messages.Any(m => m.Contains("Writing HTML output")), Is.True);
         }
 
+        [Test]
+        public async Task WriteAsync_HtmlContainsTagsFilterInput()
+        {
+            var renderer = new StubPageRenderer();
+            var context = CreateContext(jsonTestRun: "{}");
+
+            var writer = new HtmlResultWriter(renderer);
+            await writer.WriteAsync(context);
+
+            var htmlFile = Path.Combine(_tempDir, Constants.TestRunHTMLFileName);
+            var html = File.ReadAllText(htmlFile);
+            Assert.That(html, Does.Contain("filterTags"));
+        }
+
         private OutputContext CreateContext(
             string jsonTestRun,
             bool isOneLakeOutput = false,

--- a/FabInspector.Tests/Output/JsonResultWriterTests.cs
+++ b/FabInspector.Tests/Output/JsonResultWriterTests.cs
@@ -193,6 +193,32 @@ namespace FabInspector.Tests.Output
             Assert.That(testRun!.Id, Is.EqualTo(context.TestRunId));
         }
 
+        [Test]
+        public async Task WriteAsync_SerializedTestRun_IncludesTagsFilterAndResultTags()
+        {
+            var results = new List<TestResult>
+            {
+                new() { RuleName = "R1", Message = "ok", Pass = true, Tags = new List<string> { "governance", "security" } }
+            };
+
+            var context = new OutputContext
+            {
+                TestResults = results,
+                LocalOutputDirPath = _tempDir,
+                IsOneLakeOutput = false,
+                TestedFilePath = "test",
+                TagsFilter = "governance",
+            };
+
+            var writer = new JsonResultWriter();
+            await writer.WriteAsync(context);
+
+            var testRun = JsonSerializer.Deserialize<TestRun>(context.JsonTestRun);
+            Assert.That(testRun, Is.Not.Null);
+            Assert.That(testRun!.TagsFilter, Is.EqualTo("governance"));
+            Assert.That(testRun.Results.Single().Tags, Is.EqualTo(new[] { "governance", "security" }));
+        }
+
         private OutputContext CreateContext(
             IEnumerable<TestResult> results,
             bool isOneLakeOutput = false,

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -80,6 +80,13 @@ Optional, false by default. If true, rules are split across available processors
 > - Rules that call remote APIs (`apiget`, `dfsget`, `daxquery`, `sqlquery`, `scannerapi`) may hit service throttling/rate limits sooner under parallel fan-out.
 > - `scannerapi` polls for up to 5 minutes per request; parallel use with this operator is not recommended.
 
+```-tags tag1,tag2,...```  
+Optional. Comma-separated rule tags used to filter which rules run.
+- Matching is case-insensitive.
+- A rule is included when it contains **any** requested tag.
+- If omitted or empty, all applicable rules run.
+- Works with both `-rules` and `-rulescatalog`.
+
 ```-pbip filepath``` / ```-pbipreport filepath```  
 Deprecated. Use `-fabricitem` instead. Targeting a `*.pbip` file still works for local mode.
 
@@ -108,6 +115,11 @@ fab-inspector -fabricitem "C:\Files\Sales.Report" -rules ".\Files\Base-rules.jso
 fab-inspector -fabricitem "C:\Files\Sales.Report" -rules ".\Files\Base-rules.json" -formats "ADO"
 ```
 
+**Local mode — run only tagged rules (`governance` or `performance`):**
+```bash
+fab-inspector -fabricitem "C:\Files\Sales.Report" -rules ".\Files\Base-rules.json" -tags "governance,performance" -formats "Console,JSON"
+```
+
 **Local mode — CopyJob item with GitHub logging:**
 ```bash
 fab-inspector -fabricitem "C:\Files\copyjob1.CopyJob" -rules "C:\Files\Sample-CopyJob-Rules.json" -formats GitHub
@@ -126,6 +138,11 @@ fab-inspector -fabricworkspace "12345678-1234-1234-1234-123456789abc" -rules ".\
 **Item-scoped — single item, interactive auth:**
 ```bash
 fab-inspector -fabricworkspace "12345678-1234-1234-1234-123456789abc" -fabricitem "87654321-4321-4321-4321-cba987654321" -rules ".\Files\Base-rules.json" -authmethod interactive -formats Console
+```
+
+**Item-scoped — single item with tag filter + Azure CLI auth:**
+```bash
+fab-inspector -fabricworkspace "12345678-1234-1234-1234-123456789abc" -fabricitem "87654321-4321-4321-4321-cba987654321" -rules ".\Files\Base-rules.json" -authmethod azurecli -tags "security" -formats Console
 ```
 
 **Item-scoped — CI/CD pipeline with client secret:**
@@ -163,6 +180,7 @@ This is useful in agentic workflows where an agent is creating or editing Fabric
 | `rules` | Conditional | Local rules JSON path or OneLake DFS URL. Provide exactly one of `rules` or `rulesCatalogPath`. |
 | `rulesCatalogPath` | Conditional | Local rules catalog JSON path or OneLake DFS URL. Provide exactly one of `rules` or `rulesCatalogPath`. |
 | `verbose` | No | `false` by default. If `true`, passing and failing rule results are included. |
+| `tags` | No | Comma-separated tags. When supplied, rules are filtered by any matching tag (case-insensitive). If omitted or empty, all applicable rules run. |
 | `authMethod` | No | `local` (default), `interactive`, or `azurecli`. |
 | `fabricWorkspaceId` | No | Fabric workspace GUID. Required for workspace/item GUID scenarios. |
 
@@ -206,6 +224,19 @@ This is useful in agentic workflows where an agent is creating or editing Fabric
 }
 ```
 
+**Local folder + local rules (tag-filtered):**
+```json
+{
+	"tool": "inspect",
+	"arguments": {
+		"fabricItem": "C:\\Files\\Sales.Report",
+		"rules": "C:\\Rules\\Base-rules.json",
+		"tags": "governance,performance",
+		"authMethod": "local"
+	}
+}
+```
+
 **Workspace item GUID + interactive auth:**
 ```json
 {
@@ -228,7 +259,7 @@ This is useful in agentic workflows where an agent is creating or editing Fabric
 | `fabricItem` | Yes | Local path to a Fabric item/folder, or a Fabric item GUID when used with `fabricWorkspaceId`. |
 | `rules` | Conditional | Local rules JSON path or OneLake DFS URL. Provide exactly one of `rules` or `rulesCatalogPath`. |
 | `rulesCatalogPath` | Conditional | Local rules catalog JSON path or OneLake DFS URL. Provide exactly one of `rules` or `rulesCatalogPath`. |
-| `tags` | No | Comma-separated tags. When supplied, rules are filtered by any matching tag (case-insensitive). |
+| `tags` | No | Comma-separated tags. When supplied, rules are filtered by any matching tag (case-insensitive). If omitted or empty, all applicable rules are returned. |
 | `authMethod` | No | `local` (default), `interactive`, or `azurecli`. |
 | `fabricWorkspaceId` | No | Fabric workspace GUID. Required for workspace/item GUID scenarios. |
 
@@ -280,6 +311,20 @@ This is useful in agentic workflows where an agent is creating or editing Fabric
 		"fabricWorkspaceId": "12345678-1234-1234-1234-123456789abc",
 		"fabricItem": "87654321-4321-4321-4321-cba987654321",
 		"rules": "./Rules/ci-rules.json",
+		"tags": "governance,security",
+		"authMethod": "interactive"
+	}
+}
+```
+
+**Workspace-scoped (all items) + local rules (tag-filtered):**
+```json
+{
+	"tool": "discover_rules",
+	"arguments": {
+		"fabricWorkspaceId": "12345678-1234-1234-1234-123456789abc",
+		"rules": "./Rules/ci-rules.json",
+		"tags": "performance",
 		"authMethod": "interactive"
 	}
 }

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -328,4 +328,4 @@ The following environment variables are read automatically when the correspondin
 
 ---
 
-*For CI/CD pipeline setup and tutorials see [Azure DevOps and GitHub integration](usage-scenarios.md). For operator reference see [Ric Operators](Ric-Operators.md) and [FabInspector Operators](FabInspector-Operators.md).*
+*For CI/CD pipeline setup and tutorials see the example GitHub repository at https://github.com/NatVanG/fab-inspector-cicd-example. For operator reference see [Ric Operators](Ric-Operators.md) and [FabInspector Operators](FabInspector-Operators.md).*


### PR DESCRIPTION
This pull request introduces rule tags filtering and improves discoverability and filtering of rules in Fab Inspector, along with several enhancements to the CLI, output, and documentation. The main themes are improved rule targeting through tags and item types, expanded CLI and API options, and richer output (including HTML and JSON) to surface tag information.

**Rule Filtering and Discovery Enhancements:**

* Added support for rule tags filtering: a new `-tags` CLI option and `tags` parameter in the MCP tool let users run only rules containing any matching tag (case-insensitive). An empty value runs all applicable rules. Matched tags are now included in JSON and HTML output. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R19) [[2]](diffhunk://#diff-26dc8770c5ac792931e426b89bc4f6c7701c11bb5a8e670422a5bf1a1b6bf39cR27) [[3]](diffhunk://#diff-26dc8770c5ac792931e426b89bc4f6c7701c11bb5a8e670422a5bf1a1b6bf39cR39) [[4]](diffhunk://#diff-1c3f37c01bf34cda23660a2e346f72eb4d01b2ac5332e98c73e9b8cef6ec0d23R7) [[5]](diffhunk://#diff-1c3f37c01bf34cda23660a2e346f72eb4d01b2ac5332e98c73e9b8cef6ec0d23R36) [[6]](diffhunk://#diff-34fab9bd0a9ca15aae757fcfe233908ac99007d4a12755e36983f23721c0acf1R364-R397) [[7]](diffhunk://#diff-34fab9bd0a9ca15aae757fcfe233908ac99007d4a12755e36983f23721c0acf1R294) [[8]](diffhunk://#diff-b772b6a25151d60ae6b53eed474e6fb2bbf2f93ba2cf354116884e7cea7064d2R14) [[9]](diffhunk://#diff-541f12b6f01b5d81a0084bd0a879a56a3439c57e6997522ed3013f4264260770R70) [[10]](diffhunk://#diff-2ccc7d14022d3c8943edaa5672c99d4d9d3f623e00c70ec2a63977eb29bbb0e8R28) [[11]](diffhunk://#diff-e8a4c510b28257af57f278bbebc322a40cbae698d5b8fc97d5e437f81b5b8099R105-R109) [[12]](diffhunk://#diff-e8a4c510b28257af57f278bbebc322a40cbae698d5b8fc97d5e437f81b5b8099R224-R236) [[13]](diffhunk://#diff-e8a4c510b28257af57f278bbebc322a40cbae698d5b8fc97d5e437f81b5b8099R384-R401) [[14]](diffhunk://#diff-e8a4c510b28257af57f278bbebc322a40cbae698d5b8fc97d5e437f81b5b8099R508-R521) [[15]](diffhunk://#diff-e8a4c510b28257af57f278bbebc322a40cbae698d5b8fc97d5e437f81b5b8099R532) [[16]](diffhunk://#diff-e8a4c510b28257af57f278bbebc322a40cbae698d5b8fc97d5e437f81b5b8099R606)
* Added `fabricItemTypes` parameter to `discover_rules`, allowing rule discovery to filter by one or more Fabric item types without resolving a concrete item. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R19) [[2]](diffhunk://#diff-26dc8770c5ac792931e426b89bc4f6c7701c11bb5a8e670422a5bf1a1b6bf39cL51-R76) [[3]](diffhunk://#diff-e38d9f9d3c26e3e7394a73f982ade2939fba1a45aad519a2ea8a874e8cd561a8R8-R9) [[4]](diffhunk://#diff-34fab9bd0a9ca15aae757fcfe233908ac99007d4a12755e36983f23721c0acf1L202-R208)

**CLI and API Changes:**

* Updated CLI and MCP tool to expose new options for tags and item types, and to propagate these filters through the inspection engine and output context. [[1]](diffhunk://#diff-26dc8770c5ac792931e426b89bc4f6c7701c11bb5a8e670422a5bf1a1b6bf39cR27) [[2]](diffhunk://#diff-26dc8770c5ac792931e426b89bc4f6c7701c11bb5a8e670422a5bf1a1b6bf39cR39) [[3]](diffhunk://#diff-26dc8770c5ac792931e426b89bc4f6c7701c11bb5a8e670422a5bf1a1b6bf39cL51-R76) [[4]](diffhunk://#diff-e38d9f9d3c26e3e7394a73f982ade2939fba1a45aad519a2ea8a874e8cd561a8R8-R9)
* Refactored `DiscoverRules` to use an async `DiscoverRulesAsync` method and to handle new filter parameters. [[1]](diffhunk://#diff-34fab9bd0a9ca15aae757fcfe233908ac99007d4a12755e36983f23721c0acf1L190-R190) [[2]](diffhunk://#diff-658c0e23d7782c9af97c8a469f108c35186d92621ac60757a6f8087e8eeb83ddL113-R121)

**Output and UI Improvements:**

* Enhanced JSON and HTML outputs to display matched rule tags and active tag filters, and added UI elements for tag-based filtering in the HTML report. [[1]](diffhunk://#diff-e8a4c510b28257af57f278bbebc322a40cbae698d5b8fc97d5e437f81b5b8099R105-R109) [[2]](diffhunk://#diff-e8a4c510b28257af57f278bbebc322a40cbae698d5b8fc97d5e437f81b5b8099R224-R236) [[3]](diffhunk://#diff-e8a4c510b28257af57f278bbebc322a40cbae698d5b8fc97d5e437f81b5b8099R384-R401) [[4]](diffhunk://#diff-e8a4c510b28257af57f278bbebc322a40cbae698d5b8fc97d5e437f81b5b8099R508-R521) [[5]](diffhunk://#diff-e8a4c510b28257af57f278bbebc322a40cbae698d5b8fc97d5e437f81b5b8099R532) [[6]](diffhunk://#diff-e8a4c510b28257af57f278bbebc322a40cbae698d5b8fc97d5e437f81b5b8099R606) [[7]](diffhunk://#diff-2ccc7d14022d3c8943edaa5672c99d4d9d3f623e00c70ec2a63977eb29bbb0e8R28) [[8]](diffhunk://#diff-b772b6a25151d60ae6b53eed474e6fb2bbf2f93ba2cf354116884e7cea7064d2R14) [[9]](diffhunk://#diff-541f12b6f01b5d81a0084bd0a879a56a3439c57e6997522ed3013f4264260770R70)

**Documentation and Versioning:**

* Updated documentation (CLI, operators, examples, intro, usage-scenarios) to reflect new features and fixed a CI/CD pipeline reference link.
* Bumped version to `3.5.1`.

These changes make it easier to target, discover, and report on rules relevant to specific scenarios, improving both developer and user experience.